### PR TITLE
Added Link Accounts Method

### DIFF
--- a/Auth0Client/Auth0Client.h
+++ b/Auth0Client/Auth0Client.h
@@ -22,6 +22,8 @@
 
 - (UIViewController *)getAuthenticator:(NSString *)connection scope:(NSString *)scope withCompletionHandler:(void (^)(NSMutableDictionary* error))block;
 
+- (void)linkAccountAsync:(UIViewController *)controller connection:(NSString *)connection scope:(NSString *)scope auth0AccessToken:(NSString *)accessToken withCompletionHandler:(void (^)(NSMutableDictionary* error))block;
+
 - (void)loginAsync:(UIViewController*)controller withCompletionHandler:(void (^)(NSMutableDictionary* error))block;
 
 - (void)loginAsync:(UIViewController*)controller scope:(NSString *)scope withCompletionHandler:(void (^)(NSMutableDictionary* error))block;


### PR DESCRIPTION
I added a method to the Auth0Client class linkAccountAsync:connection:scope:auth0AccessToken:withCompletionHandler: for linking other accounts to an already existing auth0 Account. 

I also changed the return URL check to be case insensitive. More details on this:

I had been having issues testing Twitter login when I set my namespace to something like this: 'NameSpaceName.auth0.com'. No errors, but the callback wasn't being called. After debugging, I found that in webView:shouldStartLoadWithRequest:navigationType: inside the Auth0WebViewController, the requestURLString was coming back all lowercase. 

Now that I'm starting to understand Auth0, I see that it's the return URL I set in the dashboard application settings. But in order to fool proof this for future users, I set the return URL check to case insensitive, in case there are capitals in the namespace from instantiating the auth client. 
