### PR TITLE
Deprecate A0APIClient & A0IdentityProviderAuthenticator singletons

### DIFF
--- a/Lock/Lock/A0AppDelegate.m
+++ b/Lock/Lock/A0AppDelegate.m
@@ -49,6 +49,6 @@
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-    return [[[[A0LockApplication sharedInstance] lock] identityProviderAuthenticator] handleURL:url sourceApplication:sourceApplication];
+    return [[[A0LockApplication sharedInstance] lock] handleURL:url sourceApplication:sourceApplication];
 }
 @end

--- a/Lock/Lock/A0AppDelegate.m
+++ b/Lock/Lock/A0AppDelegate.m
@@ -29,6 +29,7 @@
     #import <Fabric/Fabric.h>
     #import <Crashlytics/Crashlytics.h>
 #endif
+#import "A0LockApplication.h"
 
 @implementation A0AppDelegate
 
@@ -48,6 +49,6 @@
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-    return [[A0IdentityProviderAuthenticator sharedInstance] handleURL:url sourceApplication:sourceApplication];
+    return [[[[A0LockApplication sharedInstance] lock] identityProviderAuthenticator] handleURL:url sourceApplication:sourceApplication];
 }
 @end

--- a/Lock/Lock/A0HomeViewController.m
+++ b/Lock/Lock/A0HomeViewController.m
@@ -81,9 +81,8 @@ static BOOL isRunningTests(void) {
 
 - (void)loginNative:(id)sender {
     [self.keychain clearAll];
-    A0LockViewController *controller = [[A0LockViewController alloc] init];
+    A0LockViewController *controller = [[A0LockViewController alloc] initWithLock:[[A0LockApplication sharedInstance] lock]];
     @weakify(self);
-    controller.lock = [[A0LockApplication sharedInstance] lock];
     controller.closable = YES;
     controller.loginAfterSignUp = YES;
     controller.usesEmail = YES;
@@ -102,9 +101,8 @@ static BOOL isRunningTests(void) {
 
 - (void)loginTouchID:(id)sender {
     [self.keychain clearAll];
-    A0TouchIDLockViewController *controller = [[A0TouchIDLockViewController alloc] init];
+    A0TouchIDLockViewController *controller = [[A0TouchIDLockViewController alloc] initWithLock:[[A0LockApplication sharedInstance] lock]];
     controller.closable = YES;
-    controller.lock = [[A0LockApplication sharedInstance] lock];
     @weakify(self);
     controller.onAuthenticationBlock = ^(A0UserProfile *profile, A0Token *token) {
         NSLog(@"SUCCESS %@", profile);
@@ -125,8 +123,7 @@ static BOOL isRunningTests(void) {
 
 - (void)loginSMS:(id)sender {
     [self.keychain clearAll];
-    A0SMSLockViewController *controller = [[A0SMSLockViewController alloc] init];
-    controller.lock = [[A0LockApplication sharedInstance] lock];
+    A0SMSLockViewController *controller = [[A0SMSLockViewController alloc] initWithLock:[[A0LockApplication sharedInstance] lock]];
     controller.closable = YES;
     @weakify(self);
     controller.auth0APIToken = ^{

--- a/Lock/Lock/A0HomeViewController.m
+++ b/Lock/Lock/A0HomeViewController.m
@@ -81,7 +81,7 @@ static BOOL isRunningTests(void) {
 
 - (void)loginNative:(id)sender {
     [self.keychain clearAll];
-    A0LockViewController *controller = [[A0LockViewController alloc] initWithLock:[[A0LockApplication sharedInstance] lock]];
+    A0LockViewController *controller = [[[A0LockApplication sharedInstance] lock] newLockViewController];
     @weakify(self);
     controller.closable = YES;
     controller.loginAfterSignUp = YES;
@@ -101,7 +101,8 @@ static BOOL isRunningTests(void) {
 
 - (void)loginTouchID:(id)sender {
     [self.keychain clearAll];
-    A0TouchIDLockViewController *controller = [[A0TouchIDLockViewController alloc] initWithLock:[[A0LockApplication sharedInstance] lock]];
+    A0Lock *lock = [[A0LockApplication sharedInstance] lock];
+    A0TouchIDLockViewController *controller = [lock newTouchIDViewController];
     controller.closable = YES;
     @weakify(self);
     controller.onAuthenticationBlock = ^(A0UserProfile *profile, A0Token *token) {
@@ -114,16 +115,13 @@ static BOOL isRunningTests(void) {
             [self performSegueWithIdentifier:@"LoggedIn" sender:self];
         }];
     };
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:controller];
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-        navController.modalPresentationStyle = UIModalPresentationFormSheet;
-    }
-    [self presentViewController:navController animated:YES completion:nil];
+    [lock presentTouchIDController:controller fromController:self];
 }
 
 - (void)loginSMS:(id)sender {
     [self.keychain clearAll];
-    A0SMSLockViewController *controller = [[A0SMSLockViewController alloc] initWithLock:[[A0LockApplication sharedInstance] lock]];
+    A0Lock *lock = [[A0LockApplication sharedInstance] lock];
+    A0SMSLockViewController *controller = [lock newSMSViewController];
     controller.closable = YES;
     @weakify(self);
     controller.auth0APIToken = ^{
@@ -141,10 +139,6 @@ static BOOL isRunningTests(void) {
             [self performSegueWithIdentifier:@"LoggedIn" sender:self];
         }];
     };
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:controller];
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-        navController.modalPresentationStyle = UIModalPresentationFormSheet;
-    }
-    [self presentViewController:navController animated:YES completion:nil];
+    [lock presentSMSController:controller fromController:self];
 }
 @end

--- a/Lock/Lock/A0LockApplication.m
+++ b/Lock/Lock/A0LockApplication.m
@@ -35,11 +35,11 @@
         A0FacebookAuthenticator *facebook = [A0FacebookAuthenticator newAuthenticatorWithDefaultPermissions];
         NSString *googlePlusClientId = [[NSBundle mainBundle] infoDictionary][@"GooglePlusClientId"];
         A0GooglePlusAuthenticator *googleplus = [A0GooglePlusAuthenticator newAuthenticatorWithClientId:googlePlusClientId];
-        [[_lock identityProviderAuthenticator] registerAuthenticationProviders:@[
-                                                                                twitter,
-                                                                                facebook,
-                                                                                googleplus,
-                                                                                ]];
+        [_lock registerAuthenticators:@[
+                                        twitter,
+                                        facebook,
+                                        googleplus,
+                                        ]];
     }
     return self;
 }

--- a/Lock/Lock/A0LockApplication.m
+++ b/Lock/Lock/A0LockApplication.m
@@ -29,7 +29,7 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _lock = [A0Lock new];
+        _lock = [A0Lock newLock];
         A0TwitterAuthenticator *twitter = [A0TwitterAuthenticator newAuthenticatorWithKey:@""
                                                                                 andSecret:@""];
         A0FacebookAuthenticator *facebook = [A0FacebookAuthenticator newAuthenticatorWithDefaultPermissions];

--- a/Lock/Lock/A0LockApplication.m
+++ b/Lock/Lock/A0LockApplication.m
@@ -32,17 +32,14 @@
         _lock = [A0Lock new];
         A0TwitterAuthenticator *twitter = [A0TwitterAuthenticator newAuthenticatorWithKey:@""
                                                                                 andSecret:@""];
-        twitter.clientProvider = _lock;
         A0FacebookAuthenticator *facebook = [A0FacebookAuthenticator newAuthenticatorWithDefaultPermissions];
-        facebook.clientProvider = _lock;
         NSString *googlePlusClientId = [[NSBundle mainBundle] infoDictionary][@"GooglePlusClientId"];
         A0GooglePlusAuthenticator *googleplus = [A0GooglePlusAuthenticator newAuthenticatorWithClientId:googlePlusClientId];
-        googleplus.clientProvider = _lock;
-        [[A0IdentityProviderAuthenticator sharedInstance] registerAuthenticationProviders:@[
-                                                                                            twitter,
-                                                                                            facebook,
-                                                                                            googleplus,
-                                                                                            ]];
+        [[_lock identityProviderAuthenticator] registerAuthenticationProviders:@[
+                                                                                twitter,
+                                                                                facebook,
+                                                                                googleplus,
+                                                                                ]];
     }
     return self;
 }

--- a/Lock/Lock/A0SettingsViewController.m
+++ b/Lock/Lock/A0SettingsViewController.m
@@ -25,6 +25,7 @@
 #import <SimpleKeychain/A0SimpleKeychain.h>
 #import <TouchIDAuth/A0TouchIDAuthentication.h>
 #import <Lock/Lock.h>
+#import "A0LockApplication.h"
 
 @interface A0SettingsViewController ()
 
@@ -63,7 +64,8 @@
 
 - (IBAction)clearKeychain:(id)sender {
     [[A0SimpleKeychain keychainWithService:@"Auth0"] clearAll];
-    [[A0IdentityProviderAuthenticator sharedInstance] clearSessions];
+    A0IdentityProviderAuthenticator *authenticator = [[[A0LockApplication sharedInstance] lock] identityProviderAuthenticator];
+    [authenticator clearSessions];
 }
 
 - (IBAction)clearTouchID:(id)sender {

--- a/Lock/Tests/A0IdentityProviderAuthenticatorSpec.m
+++ b/Lock/Tests/A0IdentityProviderAuthenticatorSpec.m
@@ -72,7 +72,7 @@ describe(@"A0SocialAuthenticator", ^{
 
         it(@"should fail with provider with no identifier", ^{
             expect(^{
-                [authenticator registerAuthenticationProvider:mockProtocol(@protocol(A0AuthenticationProvider))];
+                [authenticator registerAuthenticationProvider:mock(A0BaseAuthenticator.class)];
             }).to.raiseWithReason(NSInternalInconsistencyException, @"Provider must have a valid indentifier");
         });
 
@@ -81,7 +81,7 @@ describe(@"A0SocialAuthenticator", ^{
             __block id<A0AuthenticationProvider> facebookProvider;
 
             beforeEach(^{
-                facebookProvider = mockProtocol(@protocol(A0AuthenticationProvider));
+                facebookProvider = mock(A0BaseAuthenticator.class);
                 [given([facebookProvider identifier]) willReturn:kFBProviderId];
                 [authenticator registerAuthenticationProvider:facebookProvider];
             });
@@ -95,9 +95,9 @@ describe(@"A0SocialAuthenticator", ^{
             __block id<A0AuthenticationProvider> twitterProvider;
 
             beforeEach(^{
-                facebookProvider = mockProtocol(@protocol(A0AuthenticationProvider));
+                facebookProvider = mock(A0BaseAuthenticator.class);
                 [given([facebookProvider identifier]) willReturn:kFBProviderId];
-                twitterProvider = mockProtocol(@protocol(A0AuthenticationProvider));
+                twitterProvider = mock(A0BaseAuthenticator.class);
                 [given([twitterProvider identifier]) willReturn:kTwitterProviderId];
 
                 [authenticator registerAuthenticationProviders:@[facebookProvider, twitterProvider]];
@@ -117,9 +117,9 @@ describe(@"A0SocialAuthenticator", ^{
         __block id<A0AuthenticationProvider> twitterProvider;
 
         beforeEach(^{
-            facebookProvider = mockProtocol(@protocol(A0AuthenticationProvider));
+            facebookProvider = mock(A0BaseAuthenticator.class);
             [given([facebookProvider identifier]) willReturn:kFBProviderId];
-            twitterProvider = mockProtocol(@protocol(A0AuthenticationProvider));
+            twitterProvider = mock(A0BaseAuthenticator.class);
             [given([twitterProvider identifier]) willReturn:kTwitterProviderId];
             application = mock(A0Application.class);
             facebookStrategy = mock(A0Strategy.class);
@@ -153,7 +153,7 @@ describe(@"A0SocialAuthenticator", ^{
         void(^successBlock)(A0UserProfile *, A0Token *) = ^(A0UserProfile *profile, A0Token *token) {};
 
         beforeEach(^{
-            provider = mockProtocol(@protocol(A0AuthenticationProvider));
+            provider = mock(A0BaseAuthenticator.class);
             [given([provider identifier]) willReturn:@"provider"];
             strategy = mock(A0Strategy.class);
             [given([strategy name]) willReturn:@"provider"];
@@ -234,8 +234,8 @@ describe(@"A0SocialAuthenticator", ^{
         NSURL *twitterURL = [NSURL URLWithString:@"twitter://handler"];
 
         beforeEach(^{
-            facebook = mockProtocol(@protocol(A0AuthenticationProvider));
-            twitter = mockProtocol(@protocol(A0AuthenticationProvider));
+            facebook = mock(A0BaseAuthenticator.class);
+            twitter = mock(A0BaseAuthenticator.class);
             [given([facebook handleURL:facebookURL sourceApplication:nil]) willReturnBool:YES];
             [given([twitter handleURL:twitterURL sourceApplication:nil]) willReturnBool:YES];
             authenticator.authenticators = [@{ @"facebook": facebook, @"twitter": twitter } mutableCopy];
@@ -302,8 +302,8 @@ describe(@"A0SocialAuthenticator", ^{
         __block id<A0AuthenticationProvider> twitter;
 
         beforeEach(^{
-            facebook = mockProtocol(@protocol(A0AuthenticationProvider));
-            twitter = mockProtocol(@protocol(A0AuthenticationProvider));
+            facebook = mock(A0BaseAuthenticator.class);
+            twitter = mock(A0BaseAuthenticator.class);
             authenticator.authenticators = [@{ @"facebook": facebook, @"twitter": twitter } mutableCopy];
         });
 

--- a/Pod/Classes/Core/A0APIClient.h
+++ b/Pod/Classes/Core/A0APIClient.h
@@ -59,8 +59,8 @@ typedef void(^A0APIClientDelegationSuccess)(A0Token *tokenInfo);
 /**
  *  Returns a shared instance of `A0APIClient`. This instance is initialised with clientId and tenant from Info plist file entries. These entries are `Auth0ClientId` and `Auth0Tenant`.
  *  It can also be instantiated with a custom domain instead of Auth0's.
- *  We recommend keeping yourself the `A0APIClient` instead instead of relying in this singleton, for this reason this method is deprecated.
- *  @deprecated 1.12.0
+ *  We recommend keeping yourself the `A0APIClient` instead instead of relying in this singleton, for this reason this method is deprecated and we suggest using A0Lock class to obtain an instance of this class.
+ *  @deprecated 1.12.0. We recommend creating an instance of A0Lock and call its method `-apiClient` to obtain an instance of this object.
  *  @return a shared `A0APIClient` instance.
  */
 + (instancetype)sharedClient __attribute__((deprecated));
@@ -346,11 +346,13 @@ typedef void(^A0APIClientDelegationSuccess)(A0Token *tokenInfo);
 @interface A0APIClient (Deprecated)
 
 /**
- *  Initialise the Client with Auth0's app client ID and tenant name
+ *  Initialise the Client with Auth0's app client ID and tenant name.
+ *
  *  @param clientId app's client ID.
  *  @param tenant app's tenant name
  *
- *  @deprecated 1.12.0
+ *  @deprecated 1.12.0. Use domain & clientId to build and instance of just use A0Lock class
+ *  @see A0Lock
  *  @return a new `A0APIClient` instance
  */
 - (instancetype)initWithClientId:(NSString *)clientId andTenant:(NSString *)tenant;

--- a/Pod/Classes/Core/A0AuthenticatorProvider.h
+++ b/Pod/Classes/Core/A0AuthenticatorProvider.h
@@ -1,0 +1,31 @@
+// A0AuthenticatorProvider.h
+//
+// Copyright (c) 2015 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@class A0IdentityProviderAuthenticator;
+
+@protocol A0AuthenticatorProvider <NSObject>
+
+- (A0IdentityProviderAuthenticator *)identityProviderAuthenticator;
+
+@end

--- a/Pod/Classes/Core/A0Lock.h
+++ b/Pod/Classes/Core/A0Lock.h
@@ -22,13 +22,14 @@
 
 #import <Foundation/Foundation.h>
 #import "A0APIClientProvider.h"
+#import "A0AuthenticatorProvider.h"
 
-@class A0APIClient, A0UserAPIClient;
+@class A0APIClient, A0UserAPIClient, A0IdentityProviderAuthenticator;
 
 /**
  *  Main interface with Auth0 Lock for iOS.
  */
-@interface A0Lock : NSObject<A0APIClientProvider>
+@interface A0Lock : NSObject<A0APIClientProvider, A0AuthenticatorProvider>
 
 /**
  *  Auth0 account's client identifier
@@ -126,5 +127,13 @@
  *  @return an new API client
  */
 - (A0UserAPIClient *)newUserAPIClientWithIdToken:(NSString *)idToken;
+
+/**
+ *  Auth0 IdP authenticator for Social & Enterprise connections.
+ *  This object handles either native integrations or Web-flow for authentication.
+ *
+ *  @return a IdP authenticator instance
+ */
+- (A0IdentityProviderAuthenticator *)identityProviderAuthenticator;
 
 @end

--- a/Pod/Classes/Core/A0Lock.h
+++ b/Pod/Classes/Core/A0Lock.h
@@ -45,19 +45,7 @@
 @property (strong, readonly, nonatomic) NSURL *configurationURL;
 
 /**
- *  Initialise a new instance with values from NSBundle
- *  The valid keys are the following:
-
- *  ClientId: "Auth0ClientId"
- *  Tenant: "Auth0Tenant"
- *  Domain: "Auth0Domain"
- *  Config Domain: "Auth0ConfigurationDomain"
- *
- *  It can be any of these configurations:
- *  1. Domain + Domain Config + Client Id
- *  2. Domain + Client Id
- *  3. Tenant + Client Id
- *  The order also determines the precende, so if (1) and (2) are found in the dictionary, the option (1) will be used instead of (2).
+ *  Initialise a new instance with values from Info.plist
  *
  *  @return an instance of A0Lock
  */
@@ -111,6 +99,17 @@
                              domain:(NSString *)domain
                 configurationDomain:(NSString *)configurationDomain;
 
+
+/**
+ *  Creates a new instance of Lock using information stored in your Info.plist.
+ *  These are the the valid entries:
+ *      - Auth0ClientId: Your app's client identifier in Auth0.
+ *      - Auth0Domain: Your app's domain name or url in Auth0. e.g: samples.auth0.com or https://samples.auth0.com
+ *      - Auth0ConfigurationDomain: Your app's configuration domain name or url where we get yout app configuration. This value is optional and will default to Auth0 CDN.
+ *
+ *  @return a new instance
+ */
++ (instancetype)newLock;
 
 /**
  *  Auth0 Authentication API client.

--- a/Pod/Classes/Core/A0Lock.h
+++ b/Pod/Classes/Core/A0Lock.h
@@ -128,11 +128,30 @@
 - (A0UserAPIClient *)newUserAPIClientWithIdToken:(NSString *)idToken;
 
 /**
- *  Auth0 IdP authenticator for Social & Enterprise connections.
- *  This object handles either native integrations or Web-flow for authentication.
+ *  Handle URL received from AppDelegate when app is called from a third party app at the end of an authentication flow.
  *
- *  @return a IdP authenticator instance
+ *
+ *  @param url               url used by third party app to call the application
+ *  @param sourceApplication caller name
+ *
+ *  @return if we can handle the url or not.
  */
-- (A0IdentityProviderAuthenticator *)identityProviderAuthenticator;
+- (BOOL)handleURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
+
+/**
+ *  Register IdP authenticator that will be used for Social & Enterprise connections.
+ *  By default all Social & Enterprise authentications are performed by using the web flow with Safari but you can plug 
+ *  your own authenticator for a connection. e.g.: you can register A0FacebookAuthenticator in order to login with FB native SDK.
+ *
+ *  @param authenticators list of authenticators to register. Must be subclasses of A0BaseAuthenticator
+ *  @see A0BaseAuthenticator
+ */
+- (void)registerAuthenticators:(NSArray *)authenticators;
+
+/**
+ *  Remove all stored sessions of any IdP in your application.
+ *  If the user logged in using Safari, those sessions will not be cleaned.
+ */
+- (void)clearSessions;
 
 @end

--- a/Pod/Classes/Core/A0Lock.m
+++ b/Pod/Classes/Core/A0Lock.m
@@ -125,6 +125,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     return [self.router endpointURL];
 }
 
++ (instancetype)newLock {
+    return [[A0Lock alloc] init];
+}
+
 + (instancetype)newLockWithClientId:(NSString *)clientId domain:(NSString *)domain {
     return [[A0Lock alloc] initWithClientId:clientId domain:domain];
 }

--- a/Pod/Classes/Core/A0Lock.m
+++ b/Pod/Classes/Core/A0Lock.m
@@ -125,6 +125,18 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     return [self.router endpointURL];
 }
 
+- (BOOL)handleURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication {
+    return [self.authenticator handleURL:url sourceApplication:sourceApplication];
+}
+
+- (void)registerAuthenticators:(NSArray *)authenticators {
+    [self.identityProviderAuthenticator registerAuthenticationProviders:authenticators];
+}
+
+- (void)clearSessions {
+    [self.identityProviderAuthenticator clearSessions];
+}
+
 + (instancetype)newLock {
     return [[A0Lock alloc] init];
 }

--- a/Pod/Classes/Core/A0Lock.m
+++ b/Pod/Classes/Core/A0Lock.m
@@ -24,6 +24,7 @@
 #import "A0APIv1Router.h"
 #import "A0APIClient.h"
 #import "A0UserAPIClient.h"
+#import "A0IdentityProviderAuthenticator.h"
 
 #define kCDNConfigurationURL @"https://cdn.auth0.com"
 #define kEUCDNConfigurationURL @"https://cdn.eu.auth0.com"
@@ -51,6 +52,7 @@
 @interface A0Lock ()
 @property (strong, nonatomic) id<A0APIRouter> router;
 @property (strong, nonatomic) A0APIClient *client;
+@property (strong, nonatomic) A0IdentityProviderAuthenticator *authenticator;
 @end
 
 @implementation A0Lock
@@ -93,6 +95,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         A0LogDebug(@"Auth0 Lock initialised with clientId: (%@) domainURL: (%@) configurationURL: (%@)", clientId, domainURL, configurationURL);
         _router = [[A0APIv1Router alloc] initWithClientId:clientId domainURL:domainURL configurationURL:configurationURL];
         _client = [[A0APIClient alloc] initWithAPIRouter:_router];
+        _authenticator = [[A0IdentityProviderAuthenticator alloc] initWithLock:self];
     }
 
     return self;
@@ -100,6 +103,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
 - (A0APIClient *)apiClient {
     return self.client;
+}
+
+- (A0IdentityProviderAuthenticator *)identityProviderAuthenticator {
+    return self.authenticator;
 }
 
 - (A0UserAPIClient *)newUserAPIClientWithIdToken:(NSString *)idToken {

--- a/Pod/Classes/Core/Private/A0JSONResponseSerializer.m
+++ b/Pod/Classes/Core/Private/A0JSONResponseSerializer.m
@@ -50,7 +50,9 @@
         //FIXME: change password answer is not a valid JSON so we need this hack
         if (!responseObject && [response.URL.path isEqualToString:@"/dbconnections/change_password"]) {
             responseObject = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            *error = nil;
+            if (error != NULL) {
+                *error = nil;
+            }
         }
     }
     return responseObject;

--- a/Pod/Classes/Core/Private/A0WebAuthentication.m
+++ b/Pod/Classes/Core/Private/A0WebAuthentication.m
@@ -65,7 +65,9 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     A0Token *token;
     if (errorMessage) {
         A0LogError(@"URL contained error message %@", errorMessage);
-        *error = [errorMessage isEqualToString:@"access_denied"] ? [A0Errors auth0NotAuthorizedForStrategy:self.strategyName] : [A0Errors auth0InvalidConfigurationForStrategy:self.strategyName];
+        if (error != NULL) {
+            *error = [errorMessage isEqualToString:@"access_denied"] ? [A0Errors auth0NotAuthorizedForStrategy:self.strategyName] : [A0Errors auth0InvalidConfigurationForStrategy:self.strategyName];
+        }
     } else {
         NSString *accessToken = params[@"access_token"];
         NSString *idToken = params[@"id_token"];
@@ -76,7 +78,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
             A0LogVerbose(@"Obtained token from URL: %@", token);
         } else {
             A0LogError(@"Failed to obtain id_token from URL %@", url);
-            *error = [A0Errors auth0NotAuthorizedForStrategy:self.strategyName];
+            if (error != NULL) {
+                *error = [A0Errors auth0NotAuthorizedForStrategy:self.strategyName];
+            }
+
         }
     }
     return token;

--- a/Pod/Classes/Core/Private/NSObject+A0AuthenticatorProvider.h
+++ b/Pod/Classes/Core/Private/NSObject+A0AuthenticatorProvider.h
@@ -1,0 +1,32 @@
+// NSObject+A0AuthenticatorProvider.h
+//
+// Copyright (c) 2015 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "A0AuthenticatorProvider.h"
+
+@class A0IdentityProviderAuthenticator;
+
+@interface NSObject (A0AuthenticatorProvider)
+
+- (A0IdentityProviderAuthenticator *)a0_identityAuthenticatorFromProvider:(id<A0AuthenticatorProvider>)provider;
+
+@end

--- a/Pod/Classes/Core/Private/NSObject+A0AuthenticatorProvider.m
+++ b/Pod/Classes/Core/Private/NSObject+A0AuthenticatorProvider.m
@@ -1,0 +1,35 @@
+// NSObject+A0AuthenticatorProvider.m
+//
+// Copyright (c) 2015 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "NSObject+A0AuthenticatorProvider.h"
+#import "A0IdentityProviderAuthenticator.h"
+
+@implementation NSObject (A0AuthenticatorProvider)
+
+- (A0IdentityProviderAuthenticator *)a0_identityAuthenticatorFromProvider:(id<A0AuthenticatorProvider>)provider {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
+    return [provider identityProviderAuthenticator] ?: [A0IdentityProviderAuthenticator sharedInstance];
+#pragma GCC diagnostic pop
+}
+
+@end

--- a/Pod/Classes/Lock.h
+++ b/Pod/Classes/Lock.h
@@ -62,9 +62,11 @@
 
 #if __has_include("A0TouchIDLockViewController.h")
 #import "A0TouchIDLockViewController.h"
+#import "A0Lock+A0TouchIDLockViewController.h"
 #endif
 
 #if __has_include("A0SMSLockViewController.h")
+#import "A0Lock+A0SMSLockViewController.h"
 #import "A0SMSLockViewController.h"
 #endif
 

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
@@ -27,6 +27,8 @@
 
 /**
  *  `A0IdentityProviderAuthenticator` provides a single interface to handle all interactions with different identity providers. Each identity provider (a class that conforms with the protocol `A0AuthenticationProvider`) to be used must be registered with this object.
+ *  We recommend using `A0Lock` object instead of this object directly.
+ *  @see A0Lock
  */
 @interface A0IdentityProviderAuthenticator : NSObject
 

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
@@ -39,7 +39,7 @@
  *  Returns a shared instance of `A0IdentityProviderAuthenticator`
  *
  *  @return shared instance
- *  @deprecated 1.12.0. Obtain an instance from A0Lock instead of this method.
+ *  @deprecated 1.12.0. We recommend creating an instance of A0Lock and call its method `-identityProviderAuthenticator` to obtain an instance of this object.
  *  @see A0Lock
  */
 + (A0IdentityProviderAuthenticator *)sharedInstance __attribute__((deprecated));
@@ -52,6 +52,14 @@
  *  @return an initialized instance
  */
 - (instancetype)initWithLock:(A0Lock *)lock;
+
+/**
+ *  Initialize IdP authenticator
+ *
+ *  @return an initialized instance.
+ *  @deprecated 1.12.0. Use `-initWithLock:` instead or create an instance of A0Lock and call its method `-identityProviderAuthenticator` to obtain an instance of this object.
+ */
+- (instancetype)init __attribute__((deprecated));
 
 /**
  *  Register an array of identity providers.

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
@@ -21,9 +21,9 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "A0AuthenticationProvider.h"
+#import "A0BaseAuthenticator.h"
 
-@class A0Application, A0Strategy, A0UserProfile, A0Token, A0AuthParameters;
+@class A0Application, A0Strategy, A0UserProfile, A0Token, A0AuthParameters, A0Lock;
 
 /**
  *  `A0IdentityProviderAuthenticator` provides a single interface to handle all interactions with different identity providers. Each identity provider (a class that conforms with the protocol `A0AuthenticationProvider`) to be used must be registered with this object.
@@ -39,8 +39,19 @@
  *  Returns a shared instance of `A0IdentityProviderAuthenticator`
  *
  *  @return shared instance
+ *  @deprecated 1.12.0. Obtain an instance from A0Lock instead of this method.
+ *  @see A0Lock
  */
-+ (A0IdentityProviderAuthenticator *)sharedInstance;
++ (A0IdentityProviderAuthenticator *)sharedInstance __attribute__((deprecated));
+
+/**
+ *  Initialize IdP authenticator with for a Lock instance.
+ *
+ *  @param lock instance of A0Lock that provides app configuration and Auth API client.
+ *
+ *  @return an initialized instance
+ */
+- (instancetype)initWithLock:(A0Lock *)lock;
 
 /**
  *  Register an array of identity providers.
@@ -55,7 +66,7 @@
  *
  *  @param authenticationProvider object that conforms `A0AuthenticationProvider` protocol
  */
-- (void)registerAuthenticationProvider:(id<A0AuthenticationProvider>)authenticationProvider;
+- (void)registerAuthenticationProvider:(A0BaseAuthenticator *)authenticationProvider;
 
 /**
  *  Configures the authentication with the enabled identity providers in Auth0's application. Must be called at least once before trying to authenticate with any connection.

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.m
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.m
@@ -25,9 +25,11 @@
 #import "A0Application.h"
 #import "A0Errors.h"
 #import "A0WebAuthenticator.h"
+#import "A0Lock.h"
 
 @interface A0IdentityProviderAuthenticator ()
 
+@property (weak, nonatomic) id<A0APIClientProvider> clientProvider;
 @property (strong, nonatomic) NSMutableDictionary *registeredAuthenticators;
 @property (strong, nonatomic) NSMutableDictionary *authenticators;
 
@@ -46,11 +48,20 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     return instance;
 }
 
+- (instancetype)initWithLock:(A0Lock *)lock {
+    self = [self init];
+    if (self) {
+        _clientProvider = lock;
+    }
+    return self;
+}
+
 - (id)init {
     self = [super init];
     if (self) {
         _registeredAuthenticators = [@{} mutableCopy];
         _useWebAsDefault = YES;
+        _clientProvider = nil;
     }
     return self;
 }
@@ -61,9 +72,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     }];
 }
 
-- (void)registerAuthenticationProvider:(id<A0AuthenticationProvider>)authenticationProvider {
+- (void)registerAuthenticationProvider:(A0BaseAuthenticator *)authenticationProvider {
     NSAssert(authenticationProvider != nil, @"Must supply a non-nil profile");
     NSAssert(authenticationProvider.identifier != nil, @"Provider must have a valid indentifier");
+    authenticationProvider.clientProvider = self.clientProvider;
     self.registeredAuthenticators[authenticationProvider.identifier] = authenticationProvider;
 }
 
@@ -73,7 +85,9 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         if (self.registeredAuthenticators[strategy.name]) {
             self.authenticators[strategy.name] = self.registeredAuthenticators[strategy.name];
         } else if (self.useWebAsDefault) {
-            self.authenticators[strategy.name] = [A0WebAuthenticator newWebAuthenticationForStrategy:strategy ofApplication:application];
+            A0WebAuthenticator *authenticator = [A0WebAuthenticator newWebAuthenticationForStrategy:strategy ofApplication:application];
+            authenticator.clientProvider = self.clientProvider;
+            self.authenticators[strategy.name] = authenticator;
         }
     };
     [application.socialStrategies enumerateObjectsUsingBlock:registerBlock];

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.m
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.m
@@ -49,7 +49,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 }
 
 - (instancetype)initWithLock:(A0Lock *)lock {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
     self = [self init];
+#pragma GCC diagnostic pop
     if (self) {
         _clientProvider = lock;
     }

--- a/Pod/Classes/Provider/Twitter/A0TwitterAuthenticator.m
+++ b/Pod/Classes/Provider/Twitter/A0TwitterAuthenticator.m
@@ -272,15 +272,18 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         //   <error code="89">Error processing your OAuth request: invalid signature or token</error>
         // </errors>
         BOOL error89 = responseStr && [responseStr rangeOfString:@"<error code=\"89\">"].location != NSNotFound;
-        *error = [A0Errors twitterAppNotAuthorized];
-        if (error87) {
-            A0LogError(@"Twitter app not configured in Auth0");
-            *error = [A0Errors twitterNotConfigured];
+        if (error != NULL) {
+            *error = [A0Errors twitterAppNotAuthorized];
+            if (error87) {
+                A0LogError(@"Twitter app not configured in Auth0");
+                *error = [A0Errors twitterNotConfigured];
+            }
+            if (error89) {
+                A0LogError(@"Twitter Account in iOS is invalid. Re-enter credentials in Settings > Twitter");
+                *error = [A0Errors twitterInvalidAccount];
+            }
         }
-        if (error89) {
-            A0LogError(@"Twitter Account in iOS is invalid. Re-enter credentials in Settings > Twitter");
-            *error = [A0Errors twitterInvalidAccount];
-        }
+
     } else {
         payload = [NSURL ab_parseURLQueryString:responseStr];
         NSString *oauthToken = payload[@"oauth_token"];
@@ -288,7 +291,9 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         NSString *userId = payload[@"user_id"];
         if (!(oauthToken || oauthTokenSecret || userId)) {
             A0LogError(@"Reverse auth didnt return all credential info (token, token_secret & user_id)");
-            *error = [A0Errors twitterAppNotAuthorized];
+            if (error != NULL) {
+                *error = [A0Errors twitterAppNotAuthorized];
+            }
         }
     }
     return payload;

--- a/Pod/Classes/SMS/A0Lock+A0SMSLockViewController.h
+++ b/Pod/Classes/SMS/A0Lock+A0SMSLockViewController.h
@@ -1,6 +1,6 @@
-//  UI.h
+// A0Lock+A0SMSLockViewController.h
 //
-// Copyright (c) 2014 Auth0 (http://auth0.com)
+// Copyright (c) 2015 Auth0 (http://auth0.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef _AUTH0_IOS_SDK_UI_
-#define _AUTH0_IOS_SDK_UI_
+#import <UIKit/UIKit.h>
+#import "A0Lock.h"
 
-#import "A0Theme.h"
-#import "A0LockViewController.h"
-#import "A0LockSignUpViewController.h"
-#import "A0Lock+A0LockViewController.h"
+@class A0SMSLockViewController;
 
-#endif
+@interface A0Lock (A0SMSLockViewController)
+
+/**
+ *  Creates a new instance of `A0SMSLockViewController`
+ *
+ *  @return a new instance
+ */
+- (A0SMSLockViewController *)newSMSViewController;
+
+/**
+ *  Presents a `A0SMSLockViewController` from a UIViewController. This method takes care of embedding the `A0SMSLockViewController` inside a `UINavigationController`
+ *
+ *  @param smsController controller to present
+ *  @param controller        controller that will present the TouchID VC.
+ */
+- (void)presentSMSController:(A0SMSLockViewController *)smsController fromController:(UIViewController *)controller;
+
+@end

--- a/Pod/Classes/SMS/A0Lock+A0SMSLockViewController.m
+++ b/Pod/Classes/SMS/A0Lock+A0SMSLockViewController.m
@@ -1,6 +1,6 @@
-//  UI.h
+// A0Lock+A0SMSLockViewController.m
 //
-// Copyright (c) 2014 Auth0 (http://auth0.com)
+// Copyright (c) 2015 Auth0 (http://auth0.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef _AUTH0_IOS_SDK_UI_
-#define _AUTH0_IOS_SDK_UI_
+#import "A0Lock+A0SMSLockViewController.h"
+#import "A0SMSLockViewController.h"
 
-#import "A0Theme.h"
-#import "A0LockViewController.h"
-#import "A0LockSignUpViewController.h"
-#import "A0Lock+A0LockViewController.h"
+@implementation A0Lock (A0SMSLockViewController)
 
-#endif
+- (A0SMSLockViewController *)newSMSViewController {
+    return [[A0SMSLockViewController alloc] initWithLock:self];
+}
+
+- (void)presentSMSController:(A0SMSLockViewController *)smsController fromController:(UIViewController *)controller {
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:smsController];
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        navController.modalPresentationStyle = UIModalPresentationFormSheet;
+    }
+    [controller presentViewController:navController animated:YES completion:nil];
+}
+
+@end

--- a/Pod/Classes/SMS/A0SMSCodeViewController.m
+++ b/Pod/Classes/SMS/A0SMSCodeViewController.m
@@ -30,6 +30,7 @@
 
 #import <libextobjc/EXTScope.h>
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 @interface A0SMSCodeViewController ()
 
@@ -87,11 +88,12 @@ AUTH0_DYNAMIC_LOGGER_METHODS
             A0ShowAlertErrorView(title, message);
         };
         [self.loginButton setInProgress:YES];
-        [self.lock.apiClient loginWithPhoneNumber:self.phoneNumber
-                                         passcode:passcode
-                                       parameters:self.parameters
-                                          success:self.onAuthenticationBlock
-                                          failure:failureBlock];
+        A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+        [client loginWithPhoneNumber:self.phoneNumber
+                            passcode:passcode
+                          parameters:self.parameters
+                             success:self.onAuthenticationBlock
+                             failure:failureBlock];
     } else {
         A0LogError(@"Must provide a non-empty passcode.");
         A0ShowAlertErrorView(A0LocalizedString(@"There was an error logging in"), A0LocalizedString(@"You must enter a valid SMS code"));

--- a/Pod/Classes/SMS/A0SMSLockViewController.h
+++ b/Pod/Classes/SMS/A0SMSLockViewController.h
@@ -28,9 +28,22 @@
 @interface A0SMSLockViewController : A0ContainerViewController
 
 /**
- *  Instance of Lock with Auth0 account information. By default it will build this object with information from `Info.plist` if none is set.
+ *  Initialize a new instance of the ViewController
+ *
+ *  @param lock an instance of Lock configured for an Auth0 application
+ *  @return an initialized instance.
+ *  @see A0Lock
  */
-@property (strong, nonatomic) A0Lock *lock;
+- (instancetype)initWithLock:(A0Lock *)lock;
+
+/**
+ *  Initialize a new instance of the ViewController
+ *
+ *  @return an initialized instance.
+ *  @deprecated 1.12.0. Please use `initWithLock:` or create using an `A0Lock` instance
+ *  @see A0Lock
+ */
+- (instancetype)init __attribute__((deprecated));
 
 /**
  Allows the A0AuthenticationViewController to be dismissed by adding a button. Default is NO

--- a/Pod/Classes/SMS/A0SMSLockViewController.m
+++ b/Pod/Classes/SMS/A0SMSLockViewController.m
@@ -37,6 +37,8 @@
 
 @property (weak, nonatomic) IBOutlet UIButton *closeButton;
 
+@property (strong, nonatomic) A0Lock *lock;
+
 - (IBAction)close:(id)sender;
 
 @end
@@ -44,6 +46,15 @@
 @implementation A0SMSLockViewController
 
 AUTH0_DYNAMIC_LOGGER_METHODS
+
+- (instancetype)initWithLock:(A0Lock *)lock {
+    NSAssert(lock != nil, @"Must have a non-nil Lock instance");
+    self = [self initWithNibName:NSStringFromClass(self.class) bundle:[NSBundle bundleForClass:self.class]];
+    if (self) {
+        _lock = lock;
+    }
+    return self;
+}
 
 - (instancetype)init {
     return [self initWithNibName:NSStringFromClass(self.class) bundle:[NSBundle bundleForClass:self.class]];
@@ -85,11 +96,6 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     [self displayController:[self buildSMSSendCode]];
     UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(hideKeyboard:)];
     [self.view addGestureRecognizer:tapRecognizer];
-
-    if (!self.lock) {
-        self.lock = [[A0Lock alloc] init];
-    }
-
 }
 
 - (void)close:(id)sender {

--- a/Pod/Classes/TouchID/A0Lock+A0TouchIDLockViewController.h
+++ b/Pod/Classes/TouchID/A0Lock+A0TouchIDLockViewController.h
@@ -1,6 +1,6 @@
-//  UI.h
+// A0Lock+A0TouchIDLockViewController.h
 //
-// Copyright (c) 2014 Auth0 (http://auth0.com)
+// Copyright (c) 2015 Auth0 (http://auth0.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef _AUTH0_IOS_SDK_UI_
-#define _AUTH0_IOS_SDK_UI_
+#import <UIKit/UIKit.h>
+#import "A0Lock.h"
 
-#import "A0Theme.h"
-#import "A0LockViewController.h"
-#import "A0LockSignUpViewController.h"
-#import "A0Lock+A0LockViewController.h"
+@class A0TouchIDLockViewController;
 
-#endif
+@interface A0Lock (A0TouchIDLockViewController)
+
+/**
+ *  Creates a new instance of `A0TouchIDLockViewController`
+ *
+ *  @return a new instance
+ */
+- (A0TouchIDLockViewController *)newTouchIDViewController;
+
+/**
+ *  Presents a `A0TouchIDLockViewController` from a UIViewController. This method takes care of embedding the `A0TouchIDLockViewController` inside a `UINavigationController`
+ *
+ *  @param touchIDController controller to present
+ *  @param controller        controller that will present the TouchID VC.
+ */
+- (void)presentTouchIDController:(A0TouchIDLockViewController *)touchIDController fromController:(UIViewController *)controller;
+
+@end

--- a/Pod/Classes/TouchID/A0Lock+A0TouchIDLockViewController.m
+++ b/Pod/Classes/TouchID/A0Lock+A0TouchIDLockViewController.m
@@ -1,6 +1,6 @@
-//  UI.h
+// A0Lock+A0TouchIDLockViewController.m
 //
-// Copyright (c) 2014 Auth0 (http://auth0.com)
+// Copyright (c) 2015 Auth0 (http://auth0.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef _AUTH0_IOS_SDK_UI_
-#define _AUTH0_IOS_SDK_UI_
+#import "A0Lock+A0TouchIDLockViewController.h"
+#import "A0TouchIDLockViewController.h"
 
-#import "A0Theme.h"
-#import "A0LockViewController.h"
-#import "A0LockSignUpViewController.h"
-#import "A0Lock+A0LockViewController.h"
+@implementation A0Lock (A0TouchIDLockViewController)
 
-#endif
+- (A0TouchIDLockViewController *)newTouchIDViewController {
+    return [[A0TouchIDLockViewController alloc] initWithLock:self];
+}
+
+- (void)presentTouchIDController:(A0TouchIDLockViewController *)touchIDController fromController:(UIViewController *)controller {
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:touchIDController];
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        navController.modalPresentationStyle = UIModalPresentationFormSheet;
+    }
+    [controller presentViewController:navController animated:YES completion:nil];
+}
+@end

--- a/Pod/Classes/TouchID/A0TouchIDLockViewController.h
+++ b/Pod/Classes/TouchID/A0TouchIDLockViewController.h
@@ -35,9 +35,22 @@ FOUNDATION_EXPORT NSString * const A0ThemeTouchIDLockContainerBackgroundColor;
 @interface A0TouchIDLockViewController : UIViewController
 
 /**
- *  Instance of Lock with Auth0 account information. By default it will build this object with information from `Info.plist` if none is set.
+ *  Initialize a new instance of the ViewController
+ *
+ *  @param lock an instance of Lock configured for an Auth0 application
+ *  @return an initialized instance.
+ *  @see A0Lock
  */
-@property (strong, nonatomic) A0Lock *lock;
+- (instancetype)initWithLock:(A0Lock *)lock;
+
+/**
+ *  Initialize a new instance of the ViewController
+ *
+ *  @return an initialized instance.
+ *  @deprecated 1.12.0. Please use `initWithLock:` or create using an `A0Lock` instance
+ *  @see A0Lock
+ */
+- (instancetype)init __attribute__((deprecated));
 
 /**
  Allows the A0AuthenticationViewController to be dismissed by adding a button. Default is NO

--- a/Pod/Classes/TouchID/A0TouchIDSignUpViewController.m
+++ b/Pod/Classes/TouchID/A0TouchIDSignUpViewController.m
@@ -32,6 +32,7 @@
 #import <libextobjc/EXTScope.h>
 #import "A0EmailValidator.h"
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 @interface A0TouchIDSignUpViewController ()
 
@@ -78,7 +79,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     if (!error) {
         @weakify(self);
         A0LogDebug(@"Registering user with email %@ for TouchID", username);
-        A0APIClient *client = self.lock.apiClient;
+        A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
         [client signUpWithUsername:username
                           password:password
                     loginOnSuccess:YES

--- a/Pod/Classes/UI/A0Lock+A0LockViewController.h
+++ b/Pod/Classes/UI/A0Lock+A0LockViewController.h
@@ -1,6 +1,6 @@
-//  UI.h
+// A0Lock+A0LockViewController.h
 //
-// Copyright (c) 2014 Auth0 (http://auth0.com)
+// Copyright (c) 2015 Auth0 (http://auth0.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef _AUTH0_IOS_SDK_UI_
-#define _AUTH0_IOS_SDK_UI_
+#import "A0Lock.h"
 
-#import "A0Theme.h"
-#import "A0LockViewController.h"
-#import "A0LockSignUpViewController.h"
-#import "A0Lock+A0LockViewController.h"
+@class A0LockViewController, A0LockSignUpViewController;
 
-#endif
+@interface A0Lock (A0LockViewController)
+
+/**
+ *  Creates a new `A0LockViewController` instance
+ *
+ *  @return a new Lock ViewController
+ */
+- (A0LockViewController *)newLockViewController;
+
+/**
+ *  Creates a new `A0LockSignUpViewController` instance
+ *
+ *  @return a new Lock SignUp ViewController
+ */
+- (A0LockSignUpViewController *)newSignUpViewController;
+
+@end

--- a/Pod/Classes/UI/A0Lock+A0LockViewController.m
+++ b/Pod/Classes/UI/A0Lock+A0LockViewController.m
@@ -1,6 +1,6 @@
-//  UI.h
+// A0Lock+A0LockViewController.m
 //
-// Copyright (c) 2014 Auth0 (http://auth0.com)
+// Copyright (c) 2015 Auth0 (http://auth0.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef _AUTH0_IOS_SDK_UI_
-#define _AUTH0_IOS_SDK_UI_
-
-#import "A0Theme.h"
+#import "A0Lock+A0LockViewController.h"
 #import "A0LockViewController.h"
 #import "A0LockSignUpViewController.h"
-#import "A0Lock+A0LockViewController.h"
 
-#endif
+@implementation A0Lock (A0LockViewController)
+
+- (A0LockViewController *)newLockViewController {
+    return [[A0LockViewController alloc] initWithLock:self];
+}
+
+- (A0LockSignUpViewController *)newSignUpViewController {
+    return [[A0LockSignUpViewController alloc] initWithLock:self];
+}
+
+@end

--- a/Pod/Classes/UI/A0LockSignUpViewController.h
+++ b/Pod/Classes/UI/A0LockSignUpViewController.h
@@ -28,9 +28,22 @@
 @interface A0LockSignUpViewController : A0ContainerViewController
 
 /**
- *  Instance of Lock with Auth0 account information.
+ *  Initialize a new instance of the ViewController
+ *
+ *  @param lock an instance of Lock configured for an Auth0 application
+ *  @return an initialized instance.
+ *  @see A0Lock
  */
-@property (strong, nonatomic) A0Lock *lock;
+- (instancetype)initWithLock:(A0Lock *)lock;
+
+/**
+ *  Initialize a new instance of the ViewController
+ *
+ *  @return an initialized instance.
+ *  @deprecated 1.12.0. Please use `initWithLock:` or create using an `A0Lock` instance
+ *  @see A0Lock
+ */
+- (instancetype)init __attribute__((deprecated));
 
 /**
  Block that is called on successful authentication. It has two parameters profile and token, which will be non-nil unless login is disabled after signup.

--- a/Pod/Classes/UI/A0LockSignUpViewController.m
+++ b/Pod/Classes/UI/A0LockSignUpViewController.m
@@ -35,6 +35,7 @@
 #import "A0UIUtilities.h"
 #import "A0TitleView.h"
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 @interface A0LockSignUpViewController () <A0SmallSocialAuthenticationCollectionViewDelegate>
 
@@ -44,12 +45,22 @@
 @property (weak, nonatomic) IBOutlet A0SmallSocialAuthenticationCollectionView *serviceCollectionView;
 
 @property (strong, nonatomic) A0LockConfiguration *configuration;
+@property (strong, nonatomic) A0Lock *lock;
 
 @end
 
 @implementation A0LockSignUpViewController
 
 AUTH0_DYNAMIC_LOGGER_METHODS
+
+- (instancetype)initWithLock:(A0Lock *)lock {
+    NSAssert(lock != nil, @"Must have a non-nil Lock instance");
+    self = [self initWithNibName:NSStringFromClass(self.class) bundle:[NSBundle bundleForClass:self.class]];
+    if (self) {
+        _lock = lock;
+    }
+    return self;
+}
 
 - (instancetype)init {
     return [self initWithNibName:NSStringFromClass(self.class) bundle:[NSBundle bundleForClass:self.class]];
@@ -168,7 +179,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
 - (void)loadApplicationInfo {
     @weakify(self);
-    [self.lock.apiClient fetchAppInfoWithSuccess:^(A0Application *application) {
+    A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+    [client fetchAppInfoWithSuccess:^(A0Application *application) {
         @strongify(self);
         A0LogDebug(@"Obtained application info. Starting to build Lock UI for Sign Up...");
         [[A0IdentityProviderAuthenticator sharedInstance] configureForApplication:application];

--- a/Pod/Classes/UI/A0LockSignUpViewController.m
+++ b/Pod/Classes/UI/A0LockSignUpViewController.m
@@ -36,6 +36,7 @@
 #import "A0TitleView.h"
 #import "A0Lock.h"
 #import "NSObject+A0APIClientProvider.h"
+#import "NSObject+A0AuthenticatorProvider.h"
 
 @interface A0LockSignUpViewController () <A0SmallSocialAuthenticationCollectionViewDelegate>
 
@@ -95,7 +96,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     self.titleView.iconImage = [theme imageForKey:A0ThemeIconImageName];
     self.dismissButton.tintColor = [theme colorForKey:A0ThemeCloseButtonTintColor];
 
-    [[A0IdentityProviderAuthenticator sharedInstance] setUseWebAsDefault:!self.useWebView];
+    A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
+    [authenticator setUseWebAsDefault:!self.useWebView];
     [self displayController:[[A0LoadingViewController alloc] init]];
     [self loadApplicationInfo];
 
@@ -183,7 +185,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     [client fetchAppInfoWithSuccess:^(A0Application *application) {
         @strongify(self);
         A0LogDebug(@"Obtained application info. Starting to build Lock UI for Sign Up...");
-        [[A0IdentityProviderAuthenticator sharedInstance] configureForApplication:application];
+        A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
+        [authenticator configureForApplication:application];
         A0LockConfiguration *configuration = [[A0LockConfiguration alloc] initWithApplication:application filter:self.connections];
         configuration.defaultDatabaseConnectionName = self.defaultDatabaseConnectionName;
         self.serviceCollectionView.lock = self.lock;

--- a/Pod/Classes/UI/A0LockViewController.h
+++ b/Pod/Classes/UI/A0LockViewController.h
@@ -34,9 +34,22 @@ typedef void(^A0AuthenticationBlock)(A0UserProfile *profile, A0Token *token);
 @interface A0LockViewController : A0ContainerViewController
 
 /**
- *  Instance of Lock with Auth0 account information. By default it will build this object with information from `Info.plist` if none is set.
+ *  Initialize a new instance of the ViewController
+ *
+ *  @param lock an instance of Lock configured for an Auth0 application
+ *  @return an initialized instance.
+ *  @see A0Lock
  */
-@property (strong, nonatomic) A0Lock *lock;
+- (instancetype)initWithLock:(A0Lock *)lock;
+
+/**
+ *  Initialize a new instance of the ViewController
+ *
+ *  @return an initialized instance.
+ *  @deprecated 1.12.0. Please use `initWithLock:` or create using an `A0Lock` instance
+ *  @see A0Lock
+ */
+- (instancetype)init __attribute__((deprecated));
 
 /**
  Block that is called on successful authentication. It has two parameters profile and token, which will be non-nil unless login is disabled after signup.

--- a/Pod/Classes/UI/A0LockViewController.m
+++ b/Pod/Classes/UI/A0LockViewController.m
@@ -51,6 +51,7 @@
 #import "A0TitleView.h"
 #import "A0Lock.h"
 #import "NSObject+A0APIClientProvider.h"
+#import "NSObject+A0AuthenticatorProvider.h"
 
 @interface A0LockViewController () <UIAlertViewDelegate>
 
@@ -111,7 +112,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
     self.dismissButton.hidden = !self.closable;
 
-    [[A0IdentityProviderAuthenticator sharedInstance] setUseWebAsDefault:!self.useWebView];
+    A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
+    [authenticator setUseWebAsDefault:!self.useWebView];
     [self loadApplicationInfo];
 }
 
@@ -151,7 +153,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     [client fetchAppInfoWithSuccess:^(A0Application *application) {
         @strongify(self);
         A0LogDebug(@"Obtained application info. Starting to build Lock UI...");
-        [[A0IdentityProviderAuthenticator sharedInstance] configureForApplication:application];
+        A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
+        [authenticator configureForApplication:application];
         self.configuration = [[A0LockConfiguration alloc] initWithApplication:application filter:self.connections];
         self.configuration.defaultDatabaseConnectionName = self.defaultDatabaseConnectionName;
         [self layoutRootController];

--- a/Pod/Classes/UI/A0WebViewController.m
+++ b/Pod/Classes/UI/A0WebViewController.m
@@ -32,6 +32,7 @@
 
 #import <libextobjc/EXTScope.h>
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 @interface A0WebViewController () <UIWebViewDelegate>
 @property (weak, nonatomic) IBOutlet UIButton *cancelButton;
@@ -99,7 +100,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         if (token) {
             void(^success)(A0UserProfile *, A0Token *) = self.onAuthentication;
             @weakify(self);
-            [self.lock.apiClient fetchUserProfileWithIdToken:token.idToken success:^(A0UserProfile *profile) {
+            A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+            [client fetchUserProfileWithIdToken:token.idToken success:^(A0UserProfile *profile) {
                 @strongify(self);
                 self.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
                 if (success) {

--- a/Pod/Classes/UI/Private/A0ActiveDirectoryViewController.m
+++ b/Pod/Classes/UI/Private/A0ActiveDirectoryViewController.m
@@ -45,6 +45,7 @@
 #import "A0PasswordValidator.h"
 #import "A0Lock.h"
 #import "NSObject+A0APIClientProvider.h"
+#import "NSObject+A0AuthenticatorProvider.h"
 
 @interface A0ActiveDirectoryViewController ()
 
@@ -207,7 +208,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
     A0Application *application = [client application];
     A0Strategy *strategy = [application enterpriseStrategyWithConnection:connection.name];
-    A0IdentityProviderAuthenticator *authenticator = [A0IdentityProviderAuthenticator sharedInstance];
+    A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
     A0AuthParameters *parameters = self.parameters.copy;
     parameters[A0ParameterConnection] = connection.name;
     if ([authenticator canAuthenticateStrategy:strategy]) {

--- a/Pod/Classes/UI/Private/A0ActiveDirectoryViewController.m
+++ b/Pod/Classes/UI/Private/A0ActiveDirectoryViewController.m
@@ -44,6 +44,7 @@
 #import "A0UsernameValidator.h"
 #import "A0PasswordValidator.h"
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 @interface A0ActiveDirectoryViewController ()
 
@@ -99,7 +100,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 - (void)access:(id)sender {
     if (self.matchedConnection || self.defaultConnection) {
         A0Connection *connection = self.matchedConnection ?: self.defaultConnection;
-        A0Application *application = [self.lock.apiClient application];
+        A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+        A0Application *application = [client application];
         A0Strategy *strategy = [application enterpriseStrategyWithConnection:connection.name];
         if (!strategy.useResourceOwnerEndpoint) {
             [self loginUserWithConnection:connection];
@@ -129,7 +131,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
                 };
                 A0AuthParameters *parameters = self.parameters.copy;
                 parameters[A0ParameterConnection] = connection.name;
-                [self.lock.apiClient loginWithUsername:username password:password parameters:parameters success:success failure:failure];
+                A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+                [client loginWithUsername:username password:password parameters:parameters success:success failure:failure];
             } else {
                 [self postLoginErrorNotificationWithError:error];
                 [self.accessButton setInProgress:NO];
@@ -150,7 +153,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
 - (void)matchDomainInTextField:(UITextField *)textField {
     A0Connection *connection = [self.domainMatcher connectionForEmail:textField.text];
-    A0APIClient *client = self.lock.apiClient;
+    A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
     A0Strategy *adStrategy = client.application.activeDirectoryStrategy;
     BOOL showSingleSignOn = connection && ![adStrategy.connections containsObject:connection];
     if (showSingleSignOn) {
@@ -201,7 +204,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         }
     };
 
-    A0Application *application = [self.lock.apiClient application];
+    A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+    A0Application *application = [client application];
     A0Strategy *strategy = [application enterpriseStrategyWithConnection:connection.name];
     A0IdentityProviderAuthenticator *authenticator = [A0IdentityProviderAuthenticator sharedInstance];
     A0AuthParameters *parameters = self.parameters.copy;

--- a/Pod/Classes/UI/Private/A0ChangePasswordViewController.m
+++ b/Pod/Classes/UI/Private/A0ChangePasswordViewController.m
@@ -43,6 +43,7 @@
 #import <libextobjc/EXTScope.h>
 #import "A0ConfirmPasswordValidator.h"
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 @interface A0ChangePasswordViewController ()
 
@@ -155,11 +156,12 @@
             NSString *message = [A0Errors isAuth0Error:error withCode:A0ErrorCodeNotConnectedToInternet] ? error.localizedFailureReason : [A0Errors localizedStringForChangePasswordError:error];
             A0ShowAlertErrorView(title, message);
         };
-        [self.lock.apiClient changePassword:password
-                                forUsername:username
-                                 parameters:self.parameters
-                                    success:success
-                                    failure:failure];
+        A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+        [client changePassword:password
+                   forUsername:username
+                    parameters:self.parameters
+                       success:success
+                       failure:failure];
 
     } else {
         [self.recoverButton setInProgress:NO];

--- a/Pod/Classes/UI/Private/A0DatabaseLoginViewController.m
+++ b/Pod/Classes/UI/Private/A0DatabaseLoginViewController.m
@@ -50,6 +50,7 @@
 
 #import "UIViewController+LockNotification.h"
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 @interface A0DatabaseLoginViewController ()
 
@@ -146,7 +147,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
 - (void)access:(id)sender {
     if (self.matchedConnection) {
-        A0Application *application = [self.lock.apiClient application];
+        A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+        A0Application *application = [client application];
         A0Strategy *strategy = [application enterpriseStrategyWithConnection:self.matchedConnection.name];
         if (strategy.useResourceOwnerEndpoint) {
             if (self.onShowEnterpriseLogin) {
@@ -164,7 +166,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         [self hideKeyboard];
         NSString *username = [self.userField.textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         NSString *password = self.passwordField.textField.text;
-        A0APIClient *client = self.lock.apiClient;
+        A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
         @weakify(self);
         A0APIClientAuthenticationSuccess success = ^(A0UserProfile *profile, A0Token *token){
             @strongify(self);
@@ -258,7 +260,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         }
     };
 
-    A0Application *application = [self.lock.apiClient application];
+    A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+    A0Application *application = [client application];
     A0Strategy *strategy = [application enterpriseStrategyWithConnection:connection.name];
     A0IdentityProviderAuthenticator *authenticator = [A0IdentityProviderAuthenticator sharedInstance];
     A0AuthParameters *parameters = [self.parameters copy];

--- a/Pod/Classes/UI/Private/A0DatabaseLoginViewController.m
+++ b/Pod/Classes/UI/Private/A0DatabaseLoginViewController.m
@@ -51,6 +51,7 @@
 #import "UIViewController+LockNotification.h"
 #import "A0Lock.h"
 #import "NSObject+A0APIClientProvider.h"
+#import "NSObject+A0AuthenticatorProvider.h"
 
 @interface A0DatabaseLoginViewController ()
 
@@ -263,7 +264,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
     A0Application *application = [client application];
     A0Strategy *strategy = [application enterpriseStrategyWithConnection:connection.name];
-    A0IdentityProviderAuthenticator *authenticator = [A0IdentityProviderAuthenticator sharedInstance];
+    A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
     A0AuthParameters *parameters = [self.parameters copy];
     parameters[A0ParameterConnection] = connection.name;
     if ([authenticator canAuthenticateStrategy:strategy]) {

--- a/Pod/Classes/UI/Private/A0SignUpViewController.m
+++ b/Pod/Classes/UI/Private/A0SignUpViewController.m
@@ -44,6 +44,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <libextobjc/EXTScope.h>
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 
 @interface A0SignUpViewController ()
@@ -175,12 +176,14 @@
             NSString *message = [A0Errors isAuth0Error:error withCode:A0ErrorCodeNotConnectedToInternet] ? error.localizedFailureReason : [A0Errors localizedStringForSignUpError:error];
             A0ShowAlertErrorView(title, message);
         };
-        [self.lock.apiClient signUpWithEmail:email
-                                    username:username
-                                    password:password
-                              loginOnSuccess:self.shouldLoginUser
-                                  parameters:self.parameters
-                                     success:success failure:failure];
+        A0APIClient *client = [self a0_apiClientFromProvider:self.lock];
+        [client signUpWithEmail:email
+                       username:username
+                       password:password
+                 loginOnSuccess:self.shouldLoginUser
+                     parameters:self.parameters
+                        success:success
+                        failure:failure];
     } else {
         [self postSignUpErrorNotificationWithError:error];
         [self.signUpButton setInProgress:NO];

--- a/Pod/Classes/UI/Private/A0SmallSocialAuthenticationCollectionView.m
+++ b/Pod/Classes/UI/Private/A0SmallSocialAuthenticationCollectionView.m
@@ -38,6 +38,8 @@
 #import "A0LockNotification.h"
 #import "A0Connection.h"
 #import "A0AuthParameters.h"
+#import "NSObject+A0AuthenticatorProvider.h"
+#import "A0Lock.h"
 
 
 #define kCellIdentifier @"ServiceCell"
@@ -113,7 +115,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
     A0AuthParameters *parameters = [self.parameters copy];
     parameters[A0ParameterConnection] = strategy.name;
-    A0IdentityProviderAuthenticator *authenticator = [A0IdentityProviderAuthenticator sharedInstance];
+    A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
     if ([authenticator canAuthenticateStrategy:strategy]) {
         A0LogVerbose(@"Authenticating using third party iOS application for strategy %@", strategy.name);
         [authenticator authenticateForStrategy:strategy parameters:parameters success:successBlock failure:failureBlock];

--- a/Pod/Classes/UI/Private/A0SocialLoginViewController.m
+++ b/Pod/Classes/UI/Private/A0SocialLoginViewController.m
@@ -37,6 +37,7 @@
 #import <libextobjc/EXTScope.h>
 #import "UIViewController+LockNotification.h"
 #import "A0Lock.h"
+#import "NSObject+A0AuthenticatorProvider.h"
 
 #define kCellIdentifier @"ServiceCell"
 
@@ -112,7 +113,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         }
     };
     [self setInProgress:YES];
-    A0IdentityProviderAuthenticator *authenticator = [A0IdentityProviderAuthenticator sharedInstance];
+    A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
     if ([authenticator canAuthenticateStrategy:strategy]) {
         A0LogVerbose(@"Authenticating using third party iOS application for strategy %@", strategy.name);
         [authenticator authenticateForStrategy:strategy parameters:self.parameters success:successBlock failure:failureBlock];

--- a/Pod/Classes/UI/Private/UIViewController+LockNotification.m
+++ b/Pod/Classes/UI/Private/UIViewController+LockNotification.m
@@ -28,6 +28,7 @@
 #import "A0Connection.h"
 #import "A0AuthParameters.h"
 #import "A0Lock.h"
+#import "NSObject+A0APIClientProvider.h"
 
 @implementation UIViewController (LockNotification)
 
@@ -43,7 +44,7 @@
     NSString *connectionName;
     if ([self respondsToSelector:@selector(lock)]) {
         A0Lock *lock = [self performSelector:@selector(lock)];
-        A0APIClient *client = lock.apiClient;
+        A0APIClient *client = [self a0_apiClientFromProvider:lock];
         connectionName = parameters[@"connection"] ?: client.application.databaseStrategy.connections.firstObject;
     }
 


### PR DESCRIPTION
Now there is only one interface to use **Lock** which is the class `A0Lock`. Instead of creating a VC or using `A0APIClient` directly, the user should need to create a `A0Lock` instance and ask it for either the client or VC.

```swift
let lock = A0Lock()
let controller = lock.newLockViewController()
let client = lock.apiClient()
```

All the operations of the `A0IdentityProviderAuthenticator` are now handled directly in `A0Lock`.

