### PR TITLE
Fix crash issue iOS 7 and placeholder text color

### DIFF
--- a/Pod/Classes/SMS/A0SMSCodeViewController.m
+++ b/Pod/Classes/SMS/A0SMSCodeViewController.m
@@ -69,7 +69,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
                             range:phoneRange];
     }
     self.messageLabel.attributedText = attrString;
-    self.codeFieldView.textField.placeholder = A0LocalizedString(@"SMS Code");
+    [self.codeFieldView setFieldPlaceholderText:A0LocalizedString(@"SMS Code")];
 }
 
 - (void)login:(id)sender {

--- a/Pod/Classes/SMS/A0SMSSendCodeViewController.m
+++ b/Pod/Classes/SMS/A0SMSSendCodeViewController.m
@@ -63,7 +63,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     [theme configurePrimaryButton:self.registerButton];
     [theme configureLabel:self.messageLabel];
     self.messageLabel.text = A0LocalizedString(@"Please enter your phone number");
-    self.phoneFieldView.textField.placeholder = A0LocalizedString(@"Phone Number");
+    [self.phoneFieldView setFieldPlaceholderText:A0LocalizedString(@"Phone Number")];
     [self.registerButton setTitle:A0LocalizedString(@"SEND") forState:UIControlStateNormal];
 
     self.currentCountry = self.currentCountry ?: [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];

--- a/Pod/Classes/TouchID/A0TouchIDSignUpViewController.m
+++ b/Pod/Classes/TouchID/A0TouchIDSignUpViewController.m
@@ -68,6 +68,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     
     self.validator = [[A0EmailValidator alloc] initWithField:self.emailField.textField];
     self.title = A0LocalizedString(@"Register");
+    [self.emailField setFieldPlaceholderText:A0LocalizedString(@"Email")];
 }
 
 - (void)signUp:(id)sender {

--- a/Pod/Classes/UI/A0Theme.m
+++ b/Pod/Classes/UI/A0Theme.m
@@ -249,8 +249,12 @@ NSString * const A0ThemeCloseButtonTintColor = @"A0ThemeCloseButtonTintColor";
 }
 
 - (UIImage *)image {
-    NSBundle *bundle = self.bundleName ? [NSBundle bundleWithIdentifier:self.bundleName] : [NSBundle bundleForClass:self.class];
-    return [UIImage imageNamed:self.imageName inBundle:bundle compatibleWithTraitCollection:nil];
+    if ([UIImage respondsToSelector:@selector(imageNamed:inBundle:compatibleWithTraitCollection:)]) {
+        NSBundle *bundle = self.bundleName ? [NSBundle bundleWithIdentifier:self.bundleName] : [NSBundle bundleForClass:self.class];
+        return [UIImage imageNamed:self.imageName inBundle:bundle compatibleWithTraitCollection:nil];
+    } else {
+        return [UIImage imageNamed:self.imageName];
+    }
 }
 
 @end

--- a/Pod/Classes/UI/Private/A0ActiveDirectoryViewController.m
+++ b/Pod/Classes/UI/Private/A0ActiveDirectoryViewController.m
@@ -85,8 +85,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     
     [self.userField.textField addTarget:self action:@selector(matchDomainInTextField:) forControlEvents:UIControlEventEditingChanged];
     self.singleSignOnIcon.image = [self.singleSignOnIcon.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    self.userField.textField.placeholder = A0LocalizedString(@"Username");
-    self.passwordField.textField.placeholder = A0LocalizedString(@"Password");
+    [self.userField setFieldPlaceholderText:A0LocalizedString(@"Username")];
+    [self.passwordField setFieldPlaceholderText:A0LocalizedString(@"Password")];
     [self.accessButton setTitle:A0LocalizedString(@"ACCESS") forState:UIControlStateNormal];
     self.validator = [[A0CredentialsValidator alloc] initWithValidators:@[
                                                                           [[A0UsernameValidator alloc] initWithField:self.userField.textField],

--- a/Pod/Classes/UI/Private/A0ChangePasswordViewController.m
+++ b/Pod/Classes/UI/Private/A0ChangePasswordViewController.m
@@ -86,9 +86,9 @@
     [theme configureTextField:self.repeatPasswordField.textField];
     
     self.userField.textField.text = self.defaultEmail;
-    self.userField.textField.placeholder = A0LocalizedString(@"Email");
-    self.passwordField.textField.placeholder = A0LocalizedString(@"Password");
-    self.repeatPasswordField.textField.placeholder = A0LocalizedString(@"Confirm New Password");
+    [self.userField setFieldPlaceholderText:A0LocalizedString(@"Email")];
+    [self.passwordField setFieldPlaceholderText:A0LocalizedString(@"Password")];
+    [self.repeatPasswordField setFieldPlaceholderText:A0LocalizedString(@"Confirm New Password")];
     [self.recoverButton setTitle:A0LocalizedString(@"SEND") forState:UIControlStateNormal];
     self.messageLabel.text = A0LocalizedString(@"Please enter your email and the new password. We will send you an email to confirm the password change.");
     [self.passwordField.passwordManagerButton addTarget:self action:@selector(changeLoginInfo:) forControlEvents:UIControlEventTouchUpInside];

--- a/Pod/Classes/UI/Private/A0CredentialFieldView.h
+++ b/Pod/Classes/UI/Private/A0CredentialFieldView.h
@@ -28,4 +28,5 @@
 @property (weak, nonatomic) IBOutlet UIImageView *iconImageView;
 @property (assign, nonatomic) BOOL invalid;
 
+- (void)setFieldPlaceholderText:(NSString *)placeholderText;
 @end

--- a/Pod/Classes/UI/Private/A0CredentialFieldView.m
+++ b/Pod/Classes/UI/Private/A0CredentialFieldView.m
@@ -37,10 +37,7 @@
     self.iconImageView.image = [self.iconImageView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     self.placeholderText = self.textField.placeholder;
     self.textField.placeholder = nil;
-    self.textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.placeholderText
-                                                                           attributes:@{
-                                                                                        NSForegroundColorAttributeName: [[A0Theme sharedInstance] colorForKey:A0ThemeTextFieldPlaceholderTextColor],
-                                                                                        }];
+    [self setFieldPlaceholderText:self.placeholderText];
 }
 
 - (void)setInvalid:(BOOL)invalid {
@@ -64,4 +61,11 @@
     }
 }
 
+- (void)setFieldPlaceholderText:(NSString *)placeholderText {
+    self.placeholderText = placeholderText;
+    self.textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholderText
+                                                                           attributes:@{
+                                                                                        NSForegroundColorAttributeName: [[A0Theme sharedInstance] colorForKey:A0ThemeTextFieldPlaceholderTextColor],
+                                                                                        }];
+}
 @end

--- a/Pod/Classes/UI/Private/A0DatabaseLoginViewController.m
+++ b/Pod/Classes/UI/Private/A0DatabaseLoginViewController.m
@@ -105,14 +105,16 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     if (self.defaultConnection) {
         self.parameters[A0ParameterConnection] = self.defaultConnection.name;
     }
+    NSString *placeholderText;
     if (requiresUsername) {
-        self.userField.textField.placeholder = A0LocalizedString(@"Username/Email");
+        placeholderText = A0LocalizedString(@"Username/Email");
     } else {
-        self.userField.textField.placeholder = self.forceUsername ? A0LocalizedString(@"Username") : A0LocalizedString(@"Email");
+        placeholderText = self.forceUsername ? A0LocalizedString(@"Username") : A0LocalizedString(@"Email");
     }
+    [self.userField setFieldPlaceholderText:placeholderText];
 
     self.userField.textField.text = self.defaultUsername;
-    self.passwordField.textField.placeholder = A0LocalizedString(@"Password");
+    [self.passwordField setFieldPlaceholderText:A0LocalizedString(@"Password")];
     [self.accessButton setTitle:A0LocalizedString(@"ACCESS") forState:UIControlStateNormal];
     [self.passwordField.passwordManagerButton addTarget:self action:@selector(fillLogin:) forControlEvents:UIControlEventTouchUpInside];
     NSMutableArray *validators = [@[

--- a/Pod/Classes/UI/Private/A0SignUpViewController.m
+++ b/Pod/Classes/UI/Private/A0SignUpViewController.m
@@ -95,9 +95,9 @@
         [self.usernameSeparatorView removeFromSuperview];
         [self.credentialBoxView addConstraint:[NSLayoutConstraint constraintWithItem:self.userField attribute:NSLayoutAttributeTop relatedBy: NSLayoutRelationEqual toItem:self.credentialBoxView attribute:NSLayoutAttributeTop multiplier:1 constant:0]];
     }
-
-    self.userField.textField.placeholder = self.forceUsername && !self.requiresUsername ? A0LocalizedString(@"Username") : A0LocalizedString(@"Email");
-    self.passwordField.textField.placeholder = A0LocalizedString(@"Password");
+    [self.usernameField setFieldPlaceholderText:A0LocalizedString(@"Username")];
+    [self.userField setFieldPlaceholderText:self.forceUsername && !self.requiresUsername ? A0LocalizedString(@"Username") : A0LocalizedString(@"Email")];
+    [self.passwordField setFieldPlaceholderText:A0LocalizedString(@"Password")];
     [self.signUpButton setTitle:A0LocalizedString(@"SIGN UP") forState:UIControlStateNormal];
     self.messageLabel.text = self.forceUsername ? A0LocalizedString(@"Please enter your username and password") : A0LocalizedString(@"Please enter your email and password");
     if (self.customMessage) {


### PR DESCRIPTION
Closes #111 that cause crashes on iOS 7
Fix placeholder color in all fields in Lock.