### PR TITLE
Move FB native auth to a independent library

### DIFF
--- a/Lock.podspec
+++ b/Lock.podspec
@@ -20,7 +20,7 @@ Auth0 is a SaaS that helps you with Authentication and Authorization. You can us
 
   s.dependency 'libextobjc', '~> 0.4'
   s.dependency 'CocoaLumberjack', '~> 2.0.0-rc'
-  s.default_subspecs = 'UI', 'Facebook', 'Twitter', 'Core'
+  s.default_subspecs = 'UI', 'Twitter', 'Core'
   s.prefix_header_contents = <<-EOS
     #import "A0Logging.h"
     #define A0LocalizedString(key) NSLocalizedStringFromTable(key, @"Lock", nil)

--- a/Lock/Lock/A0AppDelegate.m
+++ b/Lock/Lock/A0AppDelegate.m
@@ -45,6 +45,7 @@
     [Fabric with:@[CrashlyticsKit]];
 #endif
     [A0LockLogger logError];
+    [[[A0LockApplication sharedInstance] lock] applicationLaunchedWithOptions:launchOptions];
     return YES;
 }
 

--- a/Lock/Lock/A0LockApplication.m
+++ b/Lock/Lock/A0LockApplication.m
@@ -23,6 +23,7 @@
 #import "A0LockApplication.h"
 
 #import <Lock/Lock.h>
+#import <Lock-Facebook/A0FacebookAuthenticator.h>
 
 @implementation A0LockApplication
 

--- a/Lock/Podfile
+++ b/Lock/Podfile
@@ -5,6 +5,7 @@ platform :ios, '8.0'
 def pod_with_warnings
   pod 'libextobjc', :inhibit_warnings => true #Ignore warnings for this lib
   pod 'BDBOAuth1Manager', :inhibit_warnings => true #Ignore warnings for this lib
+  pod 'Facebook-iOS-SDK', :inhibit_warnings => true #Ignore warnings for this lib
   pod 'ISO8601DateFormatter', :inhibit_warnings => true #Ignore warnings for this lib
 end
 
@@ -15,7 +16,7 @@ target 'Lock', :exclusive => true do
   pod 'Lock/ReactiveCore', :path => '../'
   pod 'Lock/GooglePlus', :path => '../'
   pod 'Lock/1Password', :path => '../'
-  pod 'Lock/Facebook', :path => '../'
+  pod 'Lock-Facebook', '~> 1.0'
 
   pod_with_warnings
 

--- a/Lock/Podfile
+++ b/Lock/Podfile
@@ -16,6 +16,7 @@ target 'Lock', :exclusive => true do
   pod 'Lock/ReactiveCore', :path => '../'
   pod 'Lock/GooglePlus', :path => '../'
   pod 'Lock/1Password', :path => '../'
+  pod 'Lock/Facebook', :path => '../'
 
   pod_with_warnings
 

--- a/Lock/Podfile
+++ b/Lock/Podfile
@@ -5,7 +5,6 @@ platform :ios, '8.0'
 def pod_with_warnings
   pod 'libextobjc', :inhibit_warnings => true #Ignore warnings for this lib
   pod 'BDBOAuth1Manager', :inhibit_warnings => true #Ignore warnings for this lib
-  pod 'Facebook-iOS-SDK', :inhibit_warnings => true #Ignore warnings for this lib
   pod 'ISO8601DateFormatter', :inhibit_warnings => true #Ignore warnings for this lib
 end
 

--- a/Lock/Podfile.lock
+++ b/Lock/Podfile.lock
@@ -85,6 +85,9 @@ PODS:
     - Lock/Core (= 1.11.3)
     - Lock/Twitter (= 1.11.3)
     - Lock/UI (= 1.11.3)
+  - Lock-Facebook (1.0.0):
+    - Facebook-iOS-SDK (~> 3.15)
+    - Lock/Core (~> 1.11)
   - Lock/1Password (1.11.3):
     - 1PasswordExtension (~> 1.2)
     - CocoaLumberjack (~> 2.0.0-rc)
@@ -95,11 +98,6 @@ PODS:
     - CocoaLumberjack (~> 2.0.0-rc)
     - ISO8601DateFormatter (~> 0.7)
     - libextobjc (~> 0.4)
-  - Lock/Facebook (1.11.3):
-    - CocoaLumberjack (~> 2.0.0-rc)
-    - Facebook-iOS-SDK (~> 3.15)
-    - libextobjc (~> 0.4)
-    - Lock/Core
   - Lock/GooglePlus (1.11.3):
     - CocoaLumberjack (~> 2.0.0-rc)
     - googleplus-ios-sdk (~> 1.7.1)
@@ -159,12 +157,13 @@ PODS:
 DEPENDENCIES:
   - BDBOAuth1Manager
   - Expecta
+  - Facebook-iOS-SDK
   - ISO8601DateFormatter
   - JWTDecode
   - libextobjc
   - Lock (from `../`)
+  - Lock-Facebook (~> 1.0)
   - Lock/1Password (from `../`)
-  - Lock/Facebook (from `../`)
   - Lock/GooglePlus (from `../`)
   - Lock/ReactiveCore (from `../`)
   - Lock/SMS (from `../`)
@@ -192,6 +191,7 @@ SPEC CHECKSUMS:
   JWTDecode: bff190dc06ff9ee7a3a244c454dc8ef05962c994
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
   Lock: 3fcaff54991021e52d5ed47697c125fa9b704050
+  Lock-Facebook: fc83349f48dee2d41fe8a36013502fe64a0d77fc
   LUKeychainAccess: 6479edb12cf06e11ff3336f796959eedbc58f714
   NSData+Base64: 4e84902c4db907a15673474677e57763ef3903e4
   OAuthCore: 43dce261db846a1fe20234d95654257e00e78581

--- a/Lock/Podfile.lock
+++ b/Lock/Podfile.lock
@@ -83,7 +83,6 @@ PODS:
     - CocoaLumberjack (~> 2.0.0-rc)
     - libextobjc (~> 0.4)
     - Lock/Core (= 1.11.3)
-    - Lock/Facebook (= 1.11.3)
     - Lock/Twitter (= 1.11.3)
     - Lock/UI (= 1.11.3)
   - Lock/1Password (1.11.3):
@@ -160,12 +159,12 @@ PODS:
 DEPENDENCIES:
   - BDBOAuth1Manager
   - Expecta
-  - Facebook-iOS-SDK
   - ISO8601DateFormatter
   - JWTDecode
   - libextobjc
   - Lock (from `../`)
   - Lock/1Password (from `../`)
+  - Lock/Facebook (from `../`)
   - Lock/GooglePlus (from `../`)
   - Lock/ReactiveCore (from `../`)
   - Lock/SMS (from `../`)
@@ -192,7 +191,7 @@ SPEC CHECKSUMS:
   ISO8601DateFormatter: ab926648eebe497f4d167c0fd083992f959f1274
   JWTDecode: bff190dc06ff9ee7a3a244c454dc8ef05962c994
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
-  Lock: 2ab38b864235867d45fd0d05ae4dfc7c24afa485
+  Lock: 3fcaff54991021e52d5ed47697c125fa9b704050
   LUKeychainAccess: 6479edb12cf06e11ff3336f796959eedbc58f714
   NSData+Base64: 4e84902c4db907a15673474677e57763ef3903e4
   OAuthCore: 43dce261db846a1fe20234d95654257e00e78581

--- a/Pod/Assets/SMS/A0SMSCodeViewController.xib
+++ b/Pod/Assets/SMS/A0SMSCodeViewController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="A0SMSCodeViewController">

--- a/Pod/Classes/Core/A0Lock.h
+++ b/Pod/Classes/Core/A0Lock.h
@@ -154,4 +154,11 @@
  */
 - (void)clearSessions;
 
+/**
+ *  Handle application launched event.
+ *
+ *  @param launchOptions dictionary with launch options
+ */
+- (void)applicationLaunchedWithOptions:(NSDictionary *)launchOptions;
+
 @end

--- a/Pod/Classes/Core/A0Lock.m
+++ b/Pod/Classes/Core/A0Lock.m
@@ -137,6 +137,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     [self.identityProviderAuthenticator clearSessions];
 }
 
+- (void)applicationLaunchedWithOptions:(NSDictionary *)launchOptions {
+    [self.identityProviderAuthenticator applicationLaunchedWithOptions:launchOptions];
+}
+
 + (instancetype)newLock {
     return [[A0Lock alloc] init];
 }

--- a/Pod/Classes/Provider/A0AuthenticationProvider.h
+++ b/Pod/Classes/Provider/A0AuthenticationProvider.h
@@ -52,8 +52,6 @@
  */
 - (void)clearSessions;
 
-@optional
-
 /**
  *  Handles an URL when authenticating with a third party app.
  *
@@ -63,5 +61,14 @@
  *  @return if the URL is valid
  */
 - (BOOL)handleURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
+
+/**
+ *  Notifies the Authenticator that the application has been launched. 
+ *  This method should not perform any UI or action that will alter the normal flow of an application, 
+ *  its meant to be a way to initialize the authenticator itself on application launch.
+ *
+ *  @param launchOptions Options used to launch the application
+ */
+- (void)applicationLaunchedWithOptions:(NSDictionary *)launchOptions;
 
 @end

--- a/Pod/Classes/Provider/A0BaseAuthenticator.m
+++ b/Pod/Classes/Provider/A0BaseAuthenticator.m
@@ -34,6 +34,9 @@
     return false;
 }
 
+- (void)applicationLaunchedWithOptions:(NSDictionary *)launchOptions {
+}
+
 - (void)authenticateWithParameters:(A0AuthParameters *)parameters success:(void (^)(A0UserProfile *, A0Token *))success failure:(void (^)(NSError *))failure {
     [self raiseNotImplementedException];
 }

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
@@ -138,4 +138,11 @@
  */
 - (void)clearSessions;
 
+/**
+ *  Notifies all authenticator that application has been launched.
+ *
+ *  @param launchOptions dictionary with launch options
+ */
+- (void)applicationLaunchedWithOptions:(NSDictionary *)launchOptions;
+
 @end

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.m
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.m
@@ -142,4 +142,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
 }
 
+- (void)applicationLaunchedWithOptions:(NSDictionary *)launchOptions {
+    [self.registeredAuthenticators enumerateKeysAndObjectsUsingBlock:^(NSString *key, id<A0AuthenticationProvider> authenticator, BOOL *stop) {
+        [authenticator applicationLaunchedWithOptions:launchOptions];
+    }];
+}
+
 @end

--- a/Pod/Classes/Provider/Facebook/A0FacebookAuthenticator.h
+++ b/Pod/Classes/Provider/Facebook/A0FacebookAuthenticator.h
@@ -24,10 +24,11 @@
 #import "A0BaseAuthenticator.h"
 
 /**
- *  `A0FacebookAuthentication` performs Facebook authentication of a user using Facebook iOS SDK.
+ *  `A0FacebookAuthentication` performs Facebook authentication of a user using Facebook iOS SDK v3.
+ *  @deprecated 1.12.0. Moved FB authenticator to a independent library called [Lock-Facebook](https://github.com/auth0/Lock-Facebook.iOS)
  */
+__attribute__ ((deprecated("use A0FacebookAuthenticator from 'Lock-Facebook' library")))
 @interface A0FacebookAuthenticator : A0BaseAuthenticator
-
 
 /**
  *  Creates a new instance


### PR DESCRIPTION
Start using [Lock-Facebook](https://github.com/auth0/Lock-Facebook.iOS) library instead of `Facebook` subspec.
Part of #113 