### PR TITLE
Deprecate social subspecs (FB, G+ & Twitter)

### DIFF
--- a/Lock.podspec
+++ b/Lock.podspec
@@ -20,7 +20,7 @@ Auth0 is a SaaS that helps you with Authentication and Authorization. You can us
 
   s.dependency 'libextobjc', '~> 0.4'
   s.dependency 'CocoaLumberjack', '~> 2.0.0-rc'
-  s.default_subspecs = 'UI', 'Twitter', 'Core'
+  s.default_subspecs = 'UI', 'Core'
   s.prefix_header_contents = <<-EOS
     #import "A0Logging.h"
     #define A0LocalizedString(key) NSLocalizedStringFromTable(key, @"Lock", nil)

--- a/Lock/Lock/A0LockApplication.m
+++ b/Lock/Lock/A0LockApplication.m
@@ -24,6 +24,7 @@
 
 #import <Lock/Lock.h>
 #import <Lock-Facebook/A0FacebookAuthenticator.h>
+#import <Lock-Twitter/A0TwitterAuthenticator.h>
 
 @implementation A0LockApplication
 

--- a/Lock/Lock/A0LockApplication.m
+++ b/Lock/Lock/A0LockApplication.m
@@ -25,6 +25,7 @@
 #import <Lock/Lock.h>
 #import <Lock-Facebook/A0FacebookAuthenticator.h>
 #import <Lock-Twitter/A0TwitterAuthenticator.h>
+#import <Lock-GooglePlus/A0GooglePlusAuthenticator.h>
 
 @implementation A0LockApplication
 

--- a/Lock/Podfile
+++ b/Lock/Podfile
@@ -14,10 +14,10 @@ target 'Lock', :exclusive => true do
   pod 'Lock/TouchID', :path => '../'
   pod 'Lock/SMS', :path => '../'
   pod 'Lock/ReactiveCore', :path => '../'
-  pod 'Lock/GooglePlus', :path => '../'
   pod 'Lock/1Password', :path => '../'
   pod 'Lock-Facebook', '~> 1.0'
   pod 'Lock-Twitter', '~> 1.0'
+  pod 'Lock-GooglePlus', '~> 1.0'
 
   pod_with_warnings
 

--- a/Lock/Podfile
+++ b/Lock/Podfile
@@ -17,6 +17,7 @@ target 'Lock', :exclusive => true do
   pod 'Lock/GooglePlus', :path => '../'
   pod 'Lock/1Password', :path => '../'
   pod 'Lock-Facebook', '~> 1.0'
+  pod 'Lock-Twitter', '~> 1.0'
 
   pod_with_warnings
 

--- a/Lock/Podfile.lock
+++ b/Lock/Podfile.lock
@@ -87,6 +87,9 @@ PODS:
   - Lock-Facebook (1.0.0):
     - Facebook-iOS-SDK (~> 3.15)
     - Lock/Core (~> 1.11)
+  - Lock-GooglePlus (1.0.0):
+    - googleplus-ios-sdk (~> 1.7.1)
+    - Lock/Core (~> 1.11)
   - Lock-Twitter (1.0.0):
     - BDBOAuth1Manager (~> 1.5.0)
     - Lock/Core (~> 1.11)
@@ -102,11 +105,6 @@ PODS:
     - CocoaLumberjack (~> 2.0.0-rc)
     - ISO8601DateFormatter (~> 0.7)
     - libextobjc (~> 0.4)
-  - Lock/GooglePlus (1.11.3):
-    - CocoaLumberjack (~> 2.0.0-rc)
-    - googleplus-ios-sdk (~> 1.7.1)
-    - libextobjc (~> 0.4)
-    - Lock/Core
   - Lock/ReactiveCore (1.11.3):
     - CocoaLumberjack (~> 2.0.0-rc)
     - libextobjc (~> 0.4)
@@ -160,9 +158,9 @@ DEPENDENCIES:
   - libextobjc
   - Lock (from `../`)
   - Lock-Facebook (~> 1.0)
+  - Lock-GooglePlus (~> 1.0)
   - Lock-Twitter (~> 1.0)
   - Lock/1Password (from `../`)
-  - Lock/GooglePlus (from `../`)
   - Lock/ReactiveCore (from `../`)
   - Lock/SMS (from `../`)
   - Lock/TouchID (from `../`)
@@ -190,6 +188,7 @@ SPEC CHECKSUMS:
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
   Lock: 8259572136f8b50347ff6de41e74eceb9499de2e
   Lock-Facebook: fc83349f48dee2d41fe8a36013502fe64a0d77fc
+  Lock-GooglePlus: 0d874c44c75ccaaaa35e5ba60f00214f3371162a
   Lock-Twitter: fa824ea3787f5a1b4889408062f987250b894b6d
   LUKeychainAccess: 6479edb12cf06e11ff3336f796959eedbc58f714
   NSData+Base64: 4e84902c4db907a15673474677e57763ef3903e4

--- a/Lock/Podfile.lock
+++ b/Lock/Podfile.lock
@@ -83,11 +83,15 @@ PODS:
     - CocoaLumberjack (~> 2.0.0-rc)
     - libextobjc (~> 0.4)
     - Lock/Core (= 1.11.3)
-    - Lock/Twitter (= 1.11.3)
     - Lock/UI (= 1.11.3)
   - Lock-Facebook (1.0.0):
     - Facebook-iOS-SDK (~> 3.15)
     - Lock/Core (~> 1.11)
+  - Lock-Twitter (1.0.0):
+    - BDBOAuth1Manager (~> 1.5.0)
+    - Lock/Core (~> 1.11)
+    - PSAlertView (~> 2.0)
+    - TWReverseAuth (~> 0.1.0)
   - Lock/1Password (1.11.3):
     - 1PasswordExtension (~> 1.2)
     - CocoaLumberjack (~> 2.0.0-rc)
@@ -118,13 +122,6 @@ PODS:
     - Lock/UI
     - SimpleKeychain (~> 0.2)
     - TouchIDAuth (~> 0.1)
-  - Lock/Twitter (1.11.3):
-    - BDBOAuth1Manager (~> 1.5.0)
-    - CocoaLumberjack (~> 2.0.0-rc)
-    - libextobjc (~> 0.4)
-    - Lock/Core
-    - PSAlertView (~> 2.0)
-    - TWReverseAuth (~> 0.1.0)
   - Lock/UI (1.11.3):
     - CocoaLumberjack (~> 2.0.0-rc)
     - libextobjc (~> 0.4)
@@ -163,6 +160,7 @@ DEPENDENCIES:
   - libextobjc
   - Lock (from `../`)
   - Lock-Facebook (~> 1.0)
+  - Lock-Twitter (~> 1.0)
   - Lock/1Password (from `../`)
   - Lock/GooglePlus (from `../`)
   - Lock/ReactiveCore (from `../`)
@@ -190,8 +188,9 @@ SPEC CHECKSUMS:
   ISO8601DateFormatter: ab926648eebe497f4d167c0fd083992f959f1274
   JWTDecode: bff190dc06ff9ee7a3a244c454dc8ef05962c994
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
-  Lock: 3fcaff54991021e52d5ed47697c125fa9b704050
+  Lock: 8259572136f8b50347ff6de41e74eceb9499de2e
   Lock-Facebook: fc83349f48dee2d41fe8a36013502fe64a0d77fc
+  Lock-Twitter: fa824ea3787f5a1b4889408062f987250b894b6d
   LUKeychainAccess: 6479edb12cf06e11ff3336f796959eedbc58f714
   NSData+Base64: 4e84902c4db907a15673474677e57763ef3903e4
   OAuthCore: 43dce261db846a1fe20234d95654257e00e78581

--- a/Pod/Classes/Lock.h
+++ b/Pod/Classes/Lock.h
@@ -48,16 +48,16 @@
 #import "UI.h"
 #endif
 
-#if __has_include("A0FacebookAuthenticator.h")
-#import "A0FacebookAuthenticator.h"
+#if __has_include(<Lock/A0FacebookAuthenticator.h>)
+#import <Lock/A0FacebookAuthenticator.h>
 #endif
 
-#if __has_include("A0TwitterAuthenticator.h")
-#import "A0TwitterAuthenticator.h"
+#if __has_include(<Lock/A0TwitterAuthenticator.h>)
+#import <Lock/A0TwitterAuthenticator.h>
 #endif
 
-#if __has_include("A0GooglePlusAuthenticator.h")
-#import "A0GooglePlusAuthenticator.h"
+#if __has_include(<Lock/A0GooglePlusAuthenticator.h>)
+#import <Lock/A0GooglePlusAuthenticator.h>
 #endif
 
 #if __has_include("A0TouchIDLockViewController.h")

--- a/Pod/Classes/Provider/GooglePlus/A0GooglePlusAuthenticator.h
+++ b/Pod/Classes/Provider/GooglePlus/A0GooglePlusAuthenticator.h
@@ -25,7 +25,9 @@
 
 /**
  * `A0GooglePlusAuthenticator` performs Google+ authentication using Google's official SDK.
+ *  @deprecated 1.12.0. Moved G+ authenticator to an independent library called Lock-GooglePlus (https://github.com/auth0/Lock-GooglePlus.iOS)
  */
+__attribute__ ((deprecated("use A0GooglePlusAuthenticator from 'Lock-GooglePlus' library")))
 @interface A0GooglePlusAuthenticator : A0BaseAuthenticator
 
 /**

--- a/Pod/Classes/Provider/Twitter/A0TwitterAuthenticator.h
+++ b/Pod/Classes/Provider/Twitter/A0TwitterAuthenticator.h
@@ -24,8 +24,10 @@
 #import "A0BaseAuthenticator.h"
 
 /**
- *  `A0TwitterAuthentication` handles the authentication using Twitter as an indentity provider. In order to obtain a valid token to send to Auth0 API, it uses reverse authentication with the user's login information obtained form iOS Twitter integration or from OAuth Web Flow performed in Safari
+ *  `A0TwitterAuthentication` handles the authentication using Twitter as an indentity provider. In order to obtain a valid token to send to Auth0 API, it uses reverse authentication with the user's login information obtained form iOS Twitter integration or from OAuth Web Flow performed in Safari.
+ *  @deprecated 1.12.0. Moved Twitter authenticator to an independent library called Lock-Twitter (https://github.com/auth0/Lock-Twitter.iOS)
  */
+__attribute__ ((deprecated("use A0TwitterAuthenticator from 'Lock-Twitter' library")))
 @interface A0TwitterAuthenticator : A0BaseAuthenticator
 
 /**


### PR DESCRIPTION
Start using independent libraries [Lock-Twitter](https://github.com/auth0/Lock-Twitter.iOS), [Lock-GooglePlus](https://github.com/auth0/Lock-GooglePlus.iOS) & [Lock-Facebook](https://github.com/auth0/Lock-Facebook.iOS)
Closes #113 