### PR TITLE
Move Safari based auth classes to a subpsec

### DIFF
--- a/Lock.podspec
+++ b/Lock.podspec
@@ -23,7 +23,7 @@ Auth0 is a SaaS that helps you with Authentication and Authorization. You can us
   s.requires_arc = true
 
   s.dependency 'libextobjc', '~> 0.4'
-  s.dependency 'CocoaLumberjack', '~> 2.0.0-rc'
+  s.dependency 'CocoaLumberjack', '~> 2.0'
   s.default_subspecs = 'UI', 'Core'
   s.prefix_header_contents = <<-EOS
     #import "A0Logging.h"
@@ -115,6 +115,13 @@ Auth0 is a SaaS that helps you with Authentication and Authorization. You can us
     onepassword.source_files = 'Pod/Classes/1Password/*.{h,m}'
     onepassword.dependency '1PasswordExtension', '~> 1.2'
     onepassword.dependency 'Lock/Core'
+  end
+
+  s.subspec 'Safari' do |safari|
+    safari.platform = :ios
+    safari.public_header_files = 'Pod/Classes/Safari/*.h'
+    safari.source_files = 'Pod/Classes/Safari/*.{h,m}'
+    safari.dependency 'Lock/Core'
   end
 
 end

--- a/Lock/Podfile.lock
+++ b/Lock/Podfile.lock
@@ -30,13 +30,13 @@ PODS:
   - Bolts/AppLinks (1.1.5):
     - Bolts/Tasks
   - Bolts/Tasks (1.1.5)
-  - CocoaLumberjack (2.0.0):
-    - CocoaLumberjack/Default (= 2.0.0)
-    - CocoaLumberjack/Extensions (= 2.0.0)
-  - CocoaLumberjack/Core (2.0.0)
-  - CocoaLumberjack/Default (2.0.0):
+  - CocoaLumberjack (2.0.1):
+    - CocoaLumberjack/Default (= 2.0.1)
+    - CocoaLumberjack/Extensions (= 2.0.1)
+  - CocoaLumberjack/Core (2.0.1)
+  - CocoaLumberjack/Default (2.0.1):
     - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.0.0):
+  - CocoaLumberjack/Extensions (2.0.1):
     - CocoaLumberjack/Default
   - Expecta (1.0.0)
   - FBSDKCoreKit (4.1.0):
@@ -89,7 +89,7 @@ PODS:
   - libextobjc/RuntimeExtensions (0.4.1)
   - libextobjc/UmbrellaHeader (0.4.1)
   - Lock (1.14.0):
-    - CocoaLumberjack (~> 2.0.0-rc)
+    - CocoaLumberjack (~> 2.0)
     - libextobjc (~> 0.4)
     - Lock/Core (= 1.14.0)
     - Lock/UI (= 1.14.0)
@@ -108,31 +108,31 @@ PODS:
     - TWReverseAuth (~> 0.1.0)
   - Lock/1Password (1.14.0):
     - 1PasswordExtension (~> 1.2)
-    - CocoaLumberjack (~> 2.0.0-rc)
+    - CocoaLumberjack (~> 2.0)
     - libextobjc (~> 0.4)
     - Lock/Core
   - Lock/Core (1.14.0):
     - AFNetworking (~> 2.5)
-    - CocoaLumberjack (~> 2.0.0-rc)
+    - CocoaLumberjack (~> 2.0)
     - ISO8601DateFormatter (~> 0.7)
     - libextobjc (~> 0.4)
   - Lock/ReactiveCore (1.14.0):
-    - CocoaLumberjack (~> 2.0.0-rc)
+    - CocoaLumberjack (~> 2.0)
     - libextobjc (~> 0.4)
     - Lock/Core
     - ReactiveCocoa (~> 2.3)
   - Lock/SMS (1.14.0):
-    - CocoaLumberjack (~> 2.0.0-rc)
+    - CocoaLumberjack (~> 2.0)
     - libextobjc (~> 0.4)
     - Lock/UI
   - Lock/TouchID (1.14.0):
-    - CocoaLumberjack (~> 2.0.0-rc)
+    - CocoaLumberjack (~> 2.0)
     - libextobjc (~> 0.4)
     - Lock/UI
     - SimpleKeychain (~> 0.2)
     - TouchIDAuth (~> 0.1)
   - Lock/UI (1.14.0):
-    - CocoaLumberjack (~> 2.0.0-rc)
+    - CocoaLumberjack (~> 2.0)
     - libextobjc (~> 0.4)
     - Lock/Core
   - LUKeychainAccess (1.2.4)
@@ -189,7 +189,7 @@ SPEC CHECKSUMS:
   AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
   BDBOAuth1Manager: 2e28773b58f880fb36b5cd3efcf0b1fefbc78a99
   Bolts: aac24961496d504aa56fc267cde95162a71bac39
-  CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
+  CocoaLumberjack: 019d1361244274a6138c788c6cb80baabc13fb8f
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
   FBSDKCoreKit: 469ed167195f860dbd2b4c4bbaa33d2e90598db9
   FBSDKLoginKit: ff6224762732e3698f30942e4544321b8c7a23e6
@@ -197,7 +197,7 @@ SPEC CHECKSUMS:
   ISO8601DateFormatter: ab926648eebe497f4d167c0fd083992f959f1274
   JWTDecode: bff190dc06ff9ee7a3a244c454dc8ef05962c994
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
-  Lock: afa37f1d9aa05701806c1406fdb817d207081529
+  Lock: a80ea9c48f88b516a267c6a7422ae74ff36a8a3b
   Lock-Facebook: 02c315b7d15d6fed20c7a2ea8a5e5e27c072483a
   Lock-GooglePlus: 38ea73da70d3dd3d210dfb7716b5aeed5aaabca6
   Lock-Twitter: 61168e95f6614535167621794cbada2d6606d4c5

--- a/Lock/Tests/A0IdentityProviderAuthenticatorSpec.m
+++ b/Lock/Tests/A0IdentityProviderAuthenticatorSpec.m
@@ -25,7 +25,6 @@
 #import "A0Application.h"
 #import "A0Strategy.h"
 #import "A0Errors.h"
-#import "A0WebAuthenticator.h"
 #import "A0Lock.h"
 
 #define HC_SHORTHAND

--- a/Pod/Classes/Core/A0APIClient.h
+++ b/Pod/Classes/Core/A0APIClient.h
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @deprecated 1.12.0. We recommend creating an instance of A0Lock and call its method `-apiClient` to obtain an instance of this object.
  *  @return a shared `A0APIClient` instance.
  */
-+ (instancetype)sharedClient __attribute__((deprecated));
++ (instancetype)sharedClient DEPRECATED_MSG_ATTRIBUTE("Call A0Lock -apiClient to get an instance");
 
 ///----------------------------------------
 /// @name Configuration for Auth0 App
@@ -394,7 +394,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @see A0Lock
  *  @return a new `A0APIClient` instance
  */
-- (instancetype)initWithClientId:(NSString *)clientId andTenant:(NSString *)tenant;
+- (instancetype)initWithClientId:(NSString *)clientId andTenant:(NSString *)tenant DEPRECATED_ATTRIBUTE;
 
 /**
  *  Calls Auth0 delegation API with the refresh_token to obtain a new id_token.
@@ -411,7 +411,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)delegationWithRefreshToken:(NSString *)refreshToken
                         parameters:(nullable A0AuthParameters *)parameters
                            success:(A0APIClientDelegationSuccess)success
-                           failure:(A0APIClientError)failure __attribute__((deprecated));
+                           failure:(A0APIClientError)failure DEPRECATED_ATTRIBUTE;
 
 /**
  *  Calls Auth0 delegation API with the id_token to obtain a new id_token.
@@ -428,7 +428,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)delegationWithIdToken:(NSString *)idToken
                    parameters:(nullable A0AuthParameters *)parameters
                       success:(A0APIClientDelegationSuccess)success
-                      failure:(A0APIClientError)failure __attribute__((deprecated));
+                      failure:(A0APIClientError)failure DEPRECATED_ATTRIBUTE;
 
 /**
  *  Obtains the user's profile information from Auth0 using Auth0's API accessToken
@@ -443,7 +443,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)fetchUserProfileWithAccessToken:(NSString *)accessToken
                                 success:(A0APIClientUserProfileSuccess)success
-                                failure:(A0APIClientError)failure __attribute__((deprecated));
+                                failure:(A0APIClientError)failure DEPRECATED_ATTRIBUTE;
 
 @end
 

--- a/Pod/Classes/Core/A0AuthParameters.h
+++ b/Pod/Classes/Core/A0AuthParameters.h
@@ -239,7 +239,7 @@ FOUNDATION_EXTERN NSString * const A0ParameterTarget;
  *  @param key   key for the value.
  *  @deprecated 1.12.0
  */
-- (void)setValue:(NSString *)value forKey:(NSString *)key __attribute__((deprecated));
+- (void)setValue:(NSString *)value forKey:(NSString *)key DEPRECATED_ATTRIBUTE;
 
 /**
  *  Returns a value stored using the given key
@@ -249,7 +249,7 @@ FOUNDATION_EXTERN NSString * const A0ParameterTarget;
  *
  *  @return a value or nil if it's not stored.
  */
-- (nullable NSString *)valueForKey:(NSString *)key __attribute__((deprecated));
+- (nullable NSString *)valueForKey:(NSString *)key DEPRECATED_ATTRIBUTE;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Pod/Classes/Core/A0UserAPIClient.h
+++ b/Pod/Classes/Core/A0UserAPIClient.h
@@ -97,7 +97,7 @@ typedef void(^A0UserAPIClientError)(NSError* __nonnull error);
  *  @deprecated 1.12.0
  *  @return a A0UserAPIClient instance
  */
-- (instancetype)initWithClientId:(NSString *)clientId tenant:(NSString *)tenant accessToken:(NSString *)accessToken __attribute__((deprecated));
+- (instancetype)initWithClientId:(NSString *)clientId tenant:(NSString *)tenant accessToken:(NSString *)accessToken DEPRECATED_ATTRIBUTE;
 /**
  *  Initialise a new User API Client
  *
@@ -108,7 +108,7 @@ typedef void(^A0UserAPIClientError)(NSError* __nonnull error);
  *  @deprecated 1.12.0
  *  @return a A0UserAPIClient instance
  */
-- (instancetype)initWithClientId:(NSString *)clientId tenant:(NSString *)tenant idToken:(NSString *)idToken __attribute__((deprecated));
+- (instancetype)initWithClientId:(NSString *)clientId tenant:(NSString *)tenant idToken:(NSString *)idToken DEPRECATED_ATTRIBUTE;
 
 /**
  *  Creates a new client with an access token
@@ -118,7 +118,7 @@ typedef void(^A0UserAPIClientError)(NSError* __nonnull error);
  *  @deprecated 1.12.0
  *  @return a new instance
  */
-+ (A0UserAPIClient *)clientWithAccessToken:(NSString *)accessToken __attribute__((deprecated));
++ (A0UserAPIClient *)clientWithAccessToken:(NSString *)accessToken DEPRECATED_ATTRIBUTE;
 
 /**
  *  Creates a new client with a id token
@@ -128,7 +128,7 @@ typedef void(^A0UserAPIClientError)(NSError* __nonnull error);
  *  @deprecated 1.12.0
  *  @return a new instance
  */
-+ (A0UserAPIClient *)clientWithIdToken:(NSString *)idToken __attribute__((deprecated));
++ (A0UserAPIClient *)clientWithIdToken:(NSString *)idToken DEPRECATED_ATTRIBUTE;
 
 @end
 

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.h
@@ -39,8 +39,9 @@ typedef void(^A0IdPAuthenticationErrorBlock)(NSError* __nonnull error);
 
 /**
  *  When no specific authentication provider is registered it will fallback to Safari Web Flow otherwise it will raise an error. Default is YES.
+ *  @deprecated 1.15.0. Since Apple does not allow Safari authentication by default we don't assume Safari
  */
-@property (assign, nonatomic) BOOL useWebAsDefault;
+@property (assign, nonatomic) BOOL useWebAsDefault DEPRECATED_MSG_ATTRIBUTE("By default now it raises an error when no provider is registered");
 
 /**
  *  Returns a shared instance of `A0IdentityProviderAuthenticator`
@@ -49,7 +50,7 @@ typedef void(^A0IdPAuthenticationErrorBlock)(NSError* __nonnull error);
  *  @deprecated 1.12.0. We recommend creating an instance of A0Lock and call its method `-identityProviderAuthenticator` to obtain an instance of this object.
  *  @see A0Lock
  */
-+ (A0IdentityProviderAuthenticator *)sharedInstance __attribute__((deprecated));
++ (A0IdentityProviderAuthenticator *)sharedInstance DEPRECATED_MSG_ATTRIBUTE("Use A0Lock identityProviderAuthenticator to obtain an instance");
 
 /**
  *  Initialize IdP authenticator with for a Lock instance.
@@ -66,7 +67,7 @@ typedef void(^A0IdPAuthenticationErrorBlock)(NSError* __nonnull error);
  *  @return an initialized instance.
  *  @deprecated 1.12.0. Use `-initWithLock:` instead or create an instance of A0Lock and call its method `-identityProviderAuthenticator` to obtain an instance of this object.
  */
-- (instancetype)init __attribute__((deprecated));
+- (instancetype)init DEPRECATED_MSG_ATTRIBUTE("Use -initWithLock: instead");
 
 /**
  *  Register an array of identity providers.

--- a/Pod/Classes/Provider/A0IdentityProviderAuthenticator.m
+++ b/Pod/Classes/Provider/A0IdentityProviderAuthenticator.m
@@ -24,7 +24,6 @@
 #import "A0Strategy.h"
 #import "A0Application.h"
 #import "A0Errors.h"
-#import "A0WebAuthenticator.h"
 #import "A0Lock.h"
 
 @interface A0IdentityProviderAuthenticator ()
@@ -84,10 +83,6 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     void (^registerBlock)(id obj, NSUInteger idx, BOOL *stop) = ^(A0Strategy *strategy, NSUInteger idx, BOOL *stop) {
         if (self.registeredAuthenticators[strategy.name]) {
             self.authenticators[strategy.name] = self.registeredAuthenticators[strategy.name];
-        } else if (self.useWebAsDefault) {
-            A0WebAuthenticator *authenticator = [A0WebAuthenticator newWebAuthenticationForStrategy:strategy ofApplication:application];
-            authenticator.clientProvider = self.clientProvider;
-            self.authenticators[strategy.name] = authenticator;
         }
     };
     [application.socialStrategies enumerateObjectsUsingBlock:registerBlock];

--- a/Pod/Classes/SMS/A0SMSLockViewController.h
+++ b/Pod/Classes/SMS/A0SMSLockViewController.h
@@ -43,7 +43,7 @@
  *  @deprecated 1.12.0. Please use `initWithLock:` or create using an `A0Lock` instance
  *  @see A0Lock
  */
-- (instancetype)init __attribute__((deprecated));
+- (instancetype)init DEPRECATED_ATTRIBUTE;
 
 /**
  Allows the A0AuthenticationViewController to be dismissed by adding a button. Default is NO
@@ -71,6 +71,6 @@
  *  For more info: https://api.auth0.com/docs/api/v2
  *  @deprecated 1.14.0. Lock now use `/passwordless/start` endpoint instead of API v2.
  */
-@property (copy, nonatomic) NSString *(^auth0APIToken)() __attribute__((deprecated));
+@property (copy, nonatomic) NSString *(^auth0APIToken)() DEPRECATED_MSG_ATTRIBUTE("a API v2 JWT is no longer necessary");
 
 @end

--- a/Pod/Classes/Safari/A0WebAuthenticator.h
+++ b/Pod/Classes/Safari/A0WebAuthenticator.h
@@ -21,10 +21,11 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "A0BaseAuthenticator.h"
+#import <Lock/A0BaseAuthenticator.h>
 
 @class A0Strategy, A0Application;
 
+ __attribute__((deprecated("Please use WebView authentication due to Apple rejecting apps that authenticate with Safari")))
 @interface A0WebAuthenticator : A0BaseAuthenticator
 
 + (instancetype)newWebAuthenticationForStrategy:(A0Strategy *)strategy

--- a/Pod/Classes/Safari/A0WebAuthenticator.m
+++ b/Pod/Classes/Safari/A0WebAuthenticator.m
@@ -20,20 +20,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "A0WebAuthenticator.h"
-#import "A0Application.h"
-#import "A0Strategy.h"
-#import "NSDictionary+A0QueryParameters.h"
-#import "A0UserProfile.h"
-#import "A0Token.h"
-#import "A0APIClient.h"
-#import "A0Errors.h"
-#import "A0WebAuthentication.h"
-#import "A0AuthParameters.h"
-
 #import <UIKit/UIKit.h>
-#import "NSObject+A0APIClientProvider.h"
-#import "A0Stats.h"
+
+#import "A0WebAuthenticator.h"
+#import <Lock/A0Application.h>
+#import <Lock/A0Strategy.h>
+#import <Lock/NSDictionary+A0QueryParameters.h>
+#import <Lock/A0UserProfile.h>
+#import <Lock/A0Token.h>
+#import <Lock/A0APIClient.h>
+#import <Lock/A0Errors.h>
+#import <Lock/A0WebAuthentication.h>
+#import <Lock/A0AuthParameters.h>
+#import <Lock/NSObject+A0APIClientProvider.h>
+#import <Lock/A0Stats.h>
 
 @interface A0WebAuthenticator ()
 

--- a/Pod/Classes/TouchID/A0TouchIDLockViewController.h
+++ b/Pod/Classes/TouchID/A0TouchIDLockViewController.h
@@ -50,7 +50,7 @@ FOUNDATION_EXPORT NSString * const A0ThemeTouchIDLockContainerBackgroundColor;
  *  @deprecated 1.12.0. Please use `initWithLock:` or create using an `A0Lock` instance
  *  @see A0Lock
  */
-- (instancetype)init __attribute__((deprecated));
+- (instancetype)init DEPRECATED_ATTRIBUTE;
 
 /**
  Allows the A0AuthenticationViewController to be dismissed by adding a button. Default is NO

--- a/Pod/Classes/UI/A0LockSignUpViewController.h
+++ b/Pod/Classes/UI/A0LockSignUpViewController.h
@@ -43,7 +43,7 @@
  *  @deprecated 1.12.0. Please use `initWithLock:` or create using an `A0Lock` instance
  *  @see A0Lock
  */
-- (instancetype)init __attribute__((deprecated));
+- (instancetype)init DEPRECATED_ATTRIBUTE;
 
 /**
  Block that is called on successful authentication. It has two parameters profile and token, which will be non-nil unless login is disabled after signup.

--- a/Pod/Classes/UI/A0LockSignUpViewController.m
+++ b/Pod/Classes/UI/A0LockSignUpViewController.m
@@ -96,8 +96,6 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     self.titleView.iconImage = [theme imageForKey:A0ThemeIconImageName];
     self.dismissButton.tintColor = [theme colorForKey:A0ThemeCloseButtonTintColor];
 
-    A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
-    [authenticator setUseWebAsDefault:!self.useWebView];
     [self displayController:[[A0LoadingViewController alloc] init]];
     [self loadApplicationInfo];
 

--- a/Pod/Classes/UI/A0LockViewController.h
+++ b/Pod/Classes/UI/A0LockViewController.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @deprecated 1.12.0. Please use `initWithLock:` or create using an `A0Lock` instance
  *  @see A0Lock
  */
-- (instancetype)init __attribute__((deprecated));
+- (instancetype)init DEPRECATED_ATTRIBUTE;
 
 ///------------------------------------------------
 /// @name Callbacks

--- a/Pod/Classes/UI/A0LockViewController.m
+++ b/Pod/Classes/UI/A0LockViewController.m
@@ -113,8 +113,6 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
     self.dismissButton.hidden = !self.closable;
 
-    A0IdentityProviderAuthenticator *authenticator = [self a0_identityAuthenticatorFromProvider:self.lock];
-    [authenticator setUseWebAsDefault:!self.useWebView];
     [self loadApplicationInfo];
 }
 

--- a/Pod/Classes/UI/A0Theme.h
+++ b/Pod/Classes/UI/A0Theme.h
@@ -90,6 +90,6 @@ FOUNDATION_EXPORT NSString * const A0ThemeCloseButtonTintColor;
 @end
 
 @interface A0Theme (Deprecated)
-- (void)registerImageWithName:(NSString *)name forKey:(NSString *)key __attribute__((deprecated));
+- (void)registerImageWithName:(NSString *)name forKey:(NSString *)key DEPRECATED_ATTRIBUTE;
 @end
 


### PR DESCRIPTION
This PR will remove Safari auth related classes from the default subspec of Lock and will deprecate it till iOS 9 is released and `SFSafariViewController` can be used instead.