### PR TITLE
Force all views that have autorotate disabled to portrait orientation.

### DIFF
--- a/Pod/Classes/TouchID/A0TouchIDLockViewController.m
+++ b/Pod/Classes/TouchID/A0TouchIDLockViewController.m
@@ -198,6 +198,9 @@ AUTH0_DYNAMIC_LOGGER_METHODS
                          success:self.onAuthenticationBlock
                          failure:errorBlock];
     };
+
+    //Force portrait orientation
+    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
 }
 
 - (void)close:(id)sender {

--- a/Pod/Classes/TouchID/A0TouchIDLockViewController.m
+++ b/Pod/Classes/TouchID/A0TouchIDLockViewController.m
@@ -198,11 +198,6 @@ AUTH0_DYNAMIC_LOGGER_METHODS
                          success:self.onAuthenticationBlock
                          failure:errorBlock];
     };
-
-    if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ) {
-      //Force portrait orientation
-      [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
-    }
 }
 
 - (void)close:(id)sender {
@@ -213,8 +208,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (BOOL)shouldAutorotate {
-    return NO;
+- (NSUInteger)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
 }
 
 - (void)checkTouchID:(id)sender {

--- a/Pod/Classes/TouchID/A0TouchIDLockViewController.m
+++ b/Pod/Classes/TouchID/A0TouchIDLockViewController.m
@@ -199,8 +199,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
                          failure:errorBlock];
     };
 
-    //Force portrait orientation
-    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
+    if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ) {
+      //Force portrait orientation
+      [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
+    }
 }
 
 - (void)close:(id)sender {

--- a/Pod/Classes/UI/A0LockSignUpViewController.m
+++ b/Pod/Classes/UI/A0LockSignUpViewController.m
@@ -99,8 +99,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     [self displayController:[[A0LoadingViewController alloc] init]];
     [self loadApplicationInfo];
 
-    //Force portrait orientation
-    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
+    if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ) {
+      //Force portrait orientation
+      [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
+    }
 }
 
 

--- a/Pod/Classes/UI/A0LockSignUpViewController.m
+++ b/Pod/Classes/UI/A0LockSignUpViewController.m
@@ -98,16 +98,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
     [self displayController:[[A0LoadingViewController alloc] init]];
     [self loadApplicationInfo];
-
-    if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ) {
-      //Force portrait orientation
-      [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
-    }
 }
 
-
-- (BOOL)shouldAutorotate {
-    return NO;
+- (NSUInteger)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
 }
 
 - (IBAction)dismiss:(id)sender {

--- a/Pod/Classes/UI/A0LockSignUpViewController.m
+++ b/Pod/Classes/UI/A0LockSignUpViewController.m
@@ -99,6 +99,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     [self displayController:[[A0LoadingViewController alloc] init]];
     [self loadApplicationInfo];
 
+    //Force portrait orientation
+    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
 }
 
 

--- a/Pod/Classes/UI/A0LockViewController.m
+++ b/Pod/Classes/UI/A0LockViewController.m
@@ -114,6 +114,9 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     self.dismissButton.hidden = !self.closable;
 
     [self loadApplicationInfo];
+
+    //Force portrait orientation
+    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
 }
 
 - (BOOL)shouldAutorotate {

--- a/Pod/Classes/UI/A0LockViewController.m
+++ b/Pod/Classes/UI/A0LockViewController.m
@@ -115,8 +115,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
     [self loadApplicationInfo];
 
-    //Force portrait orientation
-    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
+    if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ) {
+      //Force portrait orientation
+      [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
+    }
 }
 
 - (BOOL)shouldAutorotate {

--- a/Pod/Classes/UI/A0LockViewController.m
+++ b/Pod/Classes/UI/A0LockViewController.m
@@ -114,15 +114,10 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     self.dismissButton.hidden = !self.closable;
 
     [self loadApplicationInfo];
-
-    if ( UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone ) {
-      //Force portrait orientation
-      [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationPortrait] forKey:@"orientation"];
-    }
 }
 
-- (BOOL)shouldAutorotate {
-    return NO;
+- (NSUInteger)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
 }
 
 - (void)dismiss:(id)sender {


### PR DESCRIPTION
Lock has a bad user experience in landscape on most phones, and has autorotate disabled so users cannot reset the orientation.
On iPhone 4S this is particularly problematic as users cannot close out of the login flow due to layout issues.

This pull request forces all views where autorotate is disabled to the portrait orientation.