### PR TITLE
Added onUserSignupBlock to A0LockViewController

### DIFF
--- a/Pod/Classes/UI/A0LockViewController.h
+++ b/Pod/Classes/UI/A0LockViewController.h
@@ -67,6 +67,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (copy, nullable, nonatomic) void(^onUserDismissBlock)();
 
+/**
+ Block that is called when the user presses the "Sign Up" button on the Login Screen. Default value is nil, if set to nil then standard Auth0 Sign Up UI will be displayed.
+ This provides a customisation point allowing you to navigate to your own Sign Up interface if needed. If set, standard Sign Up UI will not be presented.
+ */
+@property (copy, nullable, nonatomic) void(^onUserSignupBlock)();
+
 ///------------------------------------------------
 /// @name UI customization
 ///------------------------------------------------

--- a/Pod/Classes/UI/A0LockViewController.m
+++ b/Pod/Classes/UI/A0LockViewController.m
@@ -264,8 +264,16 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     BOOL showResetPassword = ![self.configuration shouldDisableResetPassword:self.disableResetPassword];
     BOOL showSignUp = ![self.configuration shouldDisableSignUp:self.disableSignUp];
     if (showSignUp) {
-        [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"SIGN UP")
-                                             actionBlock:[self signUpActionBlockWithSuccess:success]];
+
+        if (self.onUserSignupBlock) {
+            [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"SIGN UP") actionBlock:self.onUserSignupBlock];
+        } else {
+            [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"SIGN UP") actionBlock:^{
+                @strongify(self);
+                A0SignUpViewController *controller = [self newSignUpViewControllerWithSuccess:success];
+                [self displayController:controller];
+            }];
+        }
     }
     if (showResetPassword) {
         [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"RESET PASSWORD") actionBlock:^{


### PR DESCRIPTION
Hey,

Due to limitations with the Sign Up UI in the `A0LockViewController`, we had been unable to use it because we need to capture additional fields however the client still wanted a way to access the Sign-Up interface from within the `A0LockViewController` (so that the users don't miss things like social sign in).

I come up with a solution to add a `onUserSignupBlock` block (similar to `onUserDismissBlock`) allowing developers to provide an override point upon the user selecting the Sign Up button. 

If `nil` (default), the SDK will work like it did previously and present the interface provided by the app however if the developer sets this block, upon the user selecting the Sign Up button, the block will be executed instead.

This means that we can do something like the following:

    A0LockViewController *controller = [[A0LockViewController alloc] initWithLock:lock];
    controller.closable = YES;
    ...
    controller.onUserDismissBlock = dismissBlock;
    controller.onUserSignupBlock = ^{
        [self presentSignupScreen];
    };


Would be great to get it merged back into the main branch so that we can still receive other updates without having to manually merge into our own fork.


Thanks