### PR TITLE
Custom SignUp UIViewController

### DIFF
--- a/Lock/Lock/A0HomeViewController.m
+++ b/Lock/Lock/A0HomeViewController.m
@@ -81,7 +81,8 @@ static BOOL isRunningTests(void) {
 
 - (void)loginNative:(id)sender {
     [self.keychain clearAll];
-    A0LockViewController *controller = [[[A0LockApplication sharedInstance] lock] newLockViewController];
+    A0Lock *lock = [[A0LockApplication sharedInstance] lock];
+    A0LockViewController *controller = [lock newLockViewController];
     @weakify(self);
     controller.closable = YES;
     controller.loginAfterSignUp = YES;
@@ -96,7 +97,7 @@ static BOOL isRunningTests(void) {
             [self performSegueWithIdentifier:@"LoggedIn" sender:self];
         }];
     };
-    [self presentViewController:controller animated:YES completion:nil];
+    [lock presentLockController:controller fromController:self];
 }
 
 - (void)loginTouchID:(id)sender {

--- a/Pod/Classes/UI/A0Lock+A0LockViewController.h
+++ b/Pod/Classes/UI/A0Lock+A0LockViewController.h
@@ -40,4 +40,12 @@
  */
 - (A0LockSignUpViewController *)newSignUpViewController;
 
+/**
+ *  Presents `A0LockViewController` from a UIViewController.
+ *
+ *  @param lockController   controller to present
+ *  @param controller       controller that will present Lock UIViewController.
+ */
+- (void)presentLockController:(A0LockViewController *)lockController fromController:(UIViewController *)controller;
+
 @end

--- a/Pod/Classes/UI/A0Lock+A0LockViewController.m
+++ b/Pod/Classes/UI/A0Lock+A0LockViewController.m
@@ -34,4 +34,9 @@
     return [[A0LockSignUpViewController alloc] initWithLock:self];
 }
 
+- (void)presentLockController:(A0LockViewController *)lockController fromController:(UIViewController *)controller {
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:lockController];
+    navigationController.navigationBarHidden = YES;
+    [controller presentViewController:navigationController animated:YES completion:nil];
+}
 @end

--- a/Pod/Classes/UI/A0LockEventDelegate.h
+++ b/Pod/Classes/UI/A0LockEventDelegate.h
@@ -1,0 +1,40 @@
+// A0LockEventDelegate.h
+//
+// Copyright (c) 2015 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class A0Token, A0UserProfile, A0LockViewController;
+
+@interface A0LockEventDelegate : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithLockViewController:(A0LockViewController *)controller NS_DESIGNATED_INITIALIZER;
+
+- (void)backToLock;
+- (void)dismissLock;
+- (void)userAuthenticatedWithToken:(A0Token *)token profile:(A0UserProfile *)profile;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/UI/A0LockEventDelegate.h
+++ b/Pod/Classes/UI/A0LockEventDelegate.h
@@ -26,13 +26,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class A0Token, A0UserProfile, A0LockViewController;
 
+/**
+ *  Object that allows to control to some extent the navigation inside Lock UI.
+ */
 @interface A0LockEventDelegate : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithLockViewController:(A0LockViewController *)controller NS_DESIGNATED_INITIALIZER;
 
+/**
+ *  Dismiss all custom UIViewControllers pushed inside Lock and shows it's main UI.
+ */
 - (void)backToLock;
+
+/**
+ *  Dismiss A0LockViewController, like tapping the close button if `closable` is true
+ */
 - (void)dismissLock;
+
+/**
+ *  Calls `onAuthenticationBlock` of `A0LockViewController` with token and profile
+ *
+ *  @param token   obtained during authentication
+ *  @param profile of the authenticated user
+ */
 - (void)userAuthenticatedWithToken:(A0Token *)token profile:(A0UserProfile *)profile;
 
 @end

--- a/Pod/Classes/UI/A0LockEventDelegate.m
+++ b/Pod/Classes/UI/A0LockEventDelegate.m
@@ -1,0 +1,58 @@
+// A0LockEventDelegate.m
+//
+// Copyright (c) 2015 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "A0LockEventDelegate.h"
+#import "A0LockViewController.h"
+#import "A0LockNotification.h"
+
+@interface A0LockEventDelegate ()
+@property (weak, nonatomic) A0LockViewController *controller;
+@end
+
+@implementation A0LockEventDelegate
+
+- (instancetype)initWithLockViewController:(A0LockViewController *)controller {
+    self = [super init];
+    if (self) {
+        _controller = controller;
+    }
+    return self;
+}
+
+- (void)dismissLock {
+    [[NSNotificationCenter defaultCenter] postNotificationName:A0LockNotificationLockDismissed object:nil];
+    [self.controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    if (self.controller.onUserDismissBlock) {
+        self.controller.onUserDismissBlock();
+    }
+}
+
+- (void)backToLock {
+    [self.controller.navigationController popToRootViewControllerAnimated:YES];
+}
+
+- (void)userAuthenticatedWithToken:(A0Token *)token profile:(A0UserProfile *)profile {
+    if (self.controller.onAuthenticationBlock) {
+        self.controller.onAuthenticationBlock(profile, token);
+    }
+}
+@end

--- a/Pod/Classes/UI/A0LockViewController.h
+++ b/Pod/Classes/UI/A0LockViewController.h
@@ -95,6 +95,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (assign, nonatomic) BOOL disableResetPassword;
 
+/**
+ *  Returns a custom UIViewController that will replace the default SignUp screen
+ */
+@property (copy, nullable, nonatomic) UIViewController *(^customSignUp)(A0Lock *lock);
+
 ///------------------------------------------------
 /// @name Authentication options
 ///------------------------------------------------

--- a/Pod/Classes/UI/A0LockViewController.h
+++ b/Pod/Classes/UI/A0LockViewController.h
@@ -22,6 +22,7 @@
 
 #import <UIKit/UIKit.h>
 #import "A0ContainerViewController.h"
+#import "A0LockEventDelegate.h"
 
 @class A0UserProfile, A0Token, A0AuthParameters, A0Lock;
 
@@ -96,9 +97,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL disableResetPassword;
 
 /**
- *  Returns a custom UIViewController that will replace the default SignUp screen
+ *  Hook to use a custom UIViewController for SignUp. By default is nil.
+ *  The block will receive two parameters:
+ *  - `A0Lock` instance of the displayed `A0LockViewController`
+ *  - an instance of `A0LockEventDelegate` used to interact with `A0LockViewController`, e.g. to go back to Lock UI.
  */
-@property (copy, nullable, nonatomic) UIViewController *(^customSignUp)(A0Lock *lock);
+@property (copy, nullable, nonatomic) UIViewController *(^customSignUp)(A0Lock *lock, A0LockEventDelegate *delegate);
 
 ///------------------------------------------------
 /// @name Authentication options

--- a/Pod/Classes/UI/A0LockViewController.m
+++ b/Pod/Classes/UI/A0LockViewController.m
@@ -268,11 +268,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     BOOL showResetPassword = ![self.configuration shouldDisableResetPassword:self.disableResetPassword];
     BOOL showSignUp = ![self.configuration shouldDisableSignUp:self.disableSignUp];
     if (showSignUp) {
-        [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"SIGN UP") actionBlock:^{
-            @strongify(self);
-            A0SignUpViewController *controller = [self newSignUpViewControllerWithSuccess:success];
-            [self displayController:controller];
-        }];
+        [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"SIGN UP")
+                                             actionBlock:[self signUpActionBlockWithSuccess:success]];
     }
     if (showResetPassword) {
         [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"RESET PASSWORD") actionBlock:^{
@@ -306,11 +303,8 @@ AUTH0_DYNAMIC_LOGGER_METHODS
     BOOL showResetPassword = ![self.configuration shouldDisableResetPassword:self.disableResetPassword];
     BOOL showSignUp = ![self.configuration shouldDisableSignUp:self.disableSignUp];
     if (showSignUp) {
-        [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"SIGN UP") actionBlock:^{
-            @strongify(self);
-            A0SignUpViewController *controller = [self newSignUpViewControllerWithSuccess:success];
-            [self displayController:controller];
-        }];
+        [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"SIGN UP")
+                                             actionBlock:[self signUpActionBlockWithSuccess:success]];
     }
     if (showResetPassword) {
         [self.navigationView addButtonWithLocalizedTitle:A0LocalizedString(@"RESET PASSWORD") actionBlock:^{
@@ -354,6 +348,23 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         [self displayController:controller];
     }];
     return controller;
+}
+
+- (void(^)())signUpActionBlockWithSuccess:(void(^)(A0UserProfile *, A0Token *))success {
+    @weakify(self);
+    if (self.navigationController && self.customSignUp) {
+        A0LogDebug(@"Using a custom SignUp UIViewController");
+        return ^{
+            @strongify(self);
+            UIViewController *controller = self.customSignUp(self.lock);
+            [self.navigationController pushViewController:controller animated:YES];
+        };
+    }
+    return ^{
+        @strongify(self);
+        A0SignUpViewController *controller = [self newSignUpViewControllerWithSuccess:success];
+        [self displayController:controller];
+    };
 }
 
 - (A0SignUpViewController *)newSignUpViewControllerWithSuccess:(void(^)(A0UserProfile *, A0Token *))success {


### PR DESCRIPTION
Allows to use a custom SignUp screen inside Lock.

To override it, the block `customSignUp` in `A0LockViewController` must be defined and Lock *MUST* be presented using the following method:

```objc
A0Lock *lock = [A0Lock sharedLock];
A0LockViewController *controller = [lock newLockViewController];
//Customise Lock
[lock presentLockController:controller fromController:self];
```

And then the `customSignUp` block should return the custom UIViewController to use instead the default one. 
> This controller will be displayed in fullscreen.

Also this block will receive two parameters:
* lock instance being used by lock controller
* delegate object to interact with lock controller e.g. to dismiss it 
