### PR TITLE
Replaces references to "openid profile"

### DIFF
--- a/Lock/Core/A0AuthParameters.h
+++ b/Lock/Core/A0AuthParameters.h
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const A0ScopeOpenId;
  */
 FOUNDATION_EXPORT NSString * const A0ScopeOfflineAccess;
 /**
- 'openid profile' scope
+ 'openid name email' scope
  */
 FOUNDATION_EXPORT NSString * const A0ScopeProfile;
 

--- a/Lock/Core/A0AuthParameters.m
+++ b/Lock/Core/A0AuthParameters.m
@@ -36,7 +36,7 @@ NSString * const A0ParameterConnection = @"connection";
 
 NSString * const A0ScopeOpenId = @"openid";
 NSString * const A0ScopeOfflineAccess = @"offline_access";
-NSString * const A0ScopeProfile = @"openid profile";
+NSString * const A0ScopeProfile = @"openid name email";
 
 NSString * const A0ParameterAPIType = @"api_type";
 NSString * const A0ParameterTarget = @"target";

--- a/LockTests/A0AuthParametersSpec.m
+++ b/LockTests/A0AuthParametersSpec.m
@@ -98,7 +98,7 @@ describe(@"A0AuthParameters", ^{
         itBehavesLike(@"valid parameter with scope", ^{
             return @{
                      @"params": [[A0AuthParameters alloc] initWithDictionary:@{
-                                                                               A0ParameterScope: @[@"openid profile", @"offline_access"],
+                                                                               A0ParameterScope: @[@"openid name email", @"offline_access"],
                                                                                }],
                      @"scopes": @[A0ScopeProfile, A0ScopeOfflineAccess],
                      };
@@ -213,7 +213,7 @@ describe(@"A0AuthParameters", ^{
         });
 
         it(@"should coalesce scopes in a NSString", ^{
-            expect(dict[A0ParameterScope]).to(equal(@"openid profile offline_access"));
+            expect(dict[A0ParameterScope]).to(equal(@"openid name email offline_access"));
         });
 
         it(@"should include specified scopes for connection", ^{


### PR DESCRIPTION
Introduces the recently recommended shorter scope by default “openid
name email”.