### PR TITLE
connection_scopes are ignored by A0WebViewAuthenticator

### DIFF
--- a/Lock/Provider/A0IdentityProviderAuthenticator.m
+++ b/Lock/Provider/A0IdentityProviderAuthenticator.m
@@ -87,7 +87,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 #ifdef HAS_WEBVIEW_SUPPORT
         A0LogDebug(@"Authenticating %@ with WebView authenticator", connectionName);
         A0WebViewAuthenticator *authenticator = [[A0WebViewAuthenticator alloc] initWithConnectionName:connectionName client:[self a0_apiClientFromProvider:self.clientProvider]];
-        [authenticator authenticateWithParameters:parameters success:success failure:failure];
+        [authenticator authenticateWithParameters:params success:success failure:failure];
 #else
         A0LogWarn(@"No known provider for connection %@", connectionName);
         if (failure) {


### PR DESCRIPTION
I am trying to use connection scopes with Facebook, but I am finding
they are ignored by A0WebViewAuthenticator - it seems that for other
IDPs the params get the 'connection' property set (in
registerAuthenticationProvider):

    params[A0ParameterConnection] = connectionName;

But this is not set for A0WebViewAuthenticator. Subsequently, when
A0WebKitViewController.initWithAPIClient is called, [parameters
asAPIPayload] returns a parameter dictionary with connection_scopes
missing, because it is trying to look up the connection scopes for the
selected connection, but no connection is set in the dictionary.

This is maybe more a band-aid than an actual fix for this issue, I'm not
sure, but it solves my problem.

see auth0/Lock.iOS-OSX#209