### PR TITLE
Preventing crash caused by cached app info

### DIFF
--- a/Lock/Core/A0APIClient.m
+++ b/Lock/Core/A0APIClient.m
@@ -115,7 +115,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 
 - (NSURLSessionDataTask *)fetchAppInfoWithSuccess:(A0APIClientFetchAppInfoSuccess)success
                                           failure:(A0APIClientError)failure {
-    NSURLRequest *request = [NSURLRequest requestWithURL:self.router.configurationURL];
+    NSURLRequest *request = [NSURLRequest requestWithURL:self.router.configurationURL cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:60];
     NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         NSRange successRange = NSMakeRange(200, 100);


### PR DESCRIPTION
Preventing cache of app info fetch. When a NSURLResponse returned from cache, it can't be converted to NSHTTPURLResponse and therefore crashes when accessing request.statusCode.