### PR TITLE
Fixed property inheritance warning

### DIFF
--- a/Lock/UI/Private/A0FullActiveDirectoryViewController.m
+++ b/Lock/UI/Private/A0FullActiveDirectoryViewController.m
@@ -36,6 +36,7 @@
 @end
 
 @implementation A0FullActiveDirectoryViewController
+@dynamic configuration;
 
 - (instancetype)init {
     return [self initWithNibName:NSStringFromClass(self.class) bundle:[NSBundle bundleForClass:self.class]];


### PR DESCRIPTION
Auto property synthesis will not synthesize property `configuration`; it will be implemented by its superclass, use @dynamic to acknowledge intention.

Either use `@dynamic` or we should remove the property declaration as it's present on the parent class `A0ActiveDirectoryViewController`