### PR TITLE
Add api_type param name to fetchNewIdTokenWithIdToken and fetchNewIdTokenWithRefreshToken 

### DIFF
--- a/Lock/Core/A0APIClient.m
+++ b/Lock/Core/A0APIClient.m
@@ -43,6 +43,7 @@
 #define kUsernameParamName @"username"
 #define kPasswordParamName @"password"
 #define kGrantTypeParamName @"grant_type"
+#define kApiTypeParamName @"api_type"
 #define kTenantParamName @"tenant"
 #define kConnectionParamName @"connection"
 #define kIdTokenParamName @"id_token"
@@ -382,7 +383,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
                                                                                kClientIdParamName: self.clientId,
                                                                                kGrantTypeParamName: @"urn:ietf:params:oauth:grant-type:jwt-bearer",
                                                                                kIdTokenParamName: idToken,
-                                                                               kGrantTypeParamName: @"app",
+                                                                               kApiTypeParamName: @"app",
                                                                                }];
     [defaultParamters addValuesFromParameters:parameters];
     return [self fetchDelegationTokenWithParameters:defaultParamters success:^(NSDictionary *tokenInfo) {
@@ -400,7 +401,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
                                                                                kClientIdParamName: self.clientId,
                                                                                kGrantTypeParamName: @"urn:ietf:params:oauth:grant-type:jwt-bearer",
                                                                                kRefreshTokenParamName: refreshToken,
-                                                                               kGrantTypeParamName: @"app",
+                                                                               kApiTypeParamName: @"app",
                                                                                }];
     [defaultParamters addValuesFromParameters:parameters];
     return [self fetchDelegationTokenWithParameters:defaultParamters success:^(NSDictionary *tokenInfo) {


### PR DESCRIPTION
The `/delegation` endpoint expects an api_type for requesting a new id_token. In case a user activated an addon like Layer the framework returns an error since no  `api_type` was sent to the server. So far the dictionary inside `fetchNewIdTokenWithIdToken` and `fetchNewIdTokenWithRefreshToken` implemented twice `kGrantTypeParamName`. The second key should be `api_type` and not `grant_type`.