### PR TITLE
Fix SMS fields.

### DIFF
--- a/Lock/SMS/Private/A0PhoneFieldView.m
+++ b/Lock/SMS/Private/A0PhoneFieldView.m
@@ -76,7 +76,7 @@
 }
 
 - (void)setupViews {
-    self.type = A0CredentialFieldViewEmail;
+    self.type = A0CredentialFieldViewPhoneNumber;
     self.returnKeyType = UIReturnKeyNext;
     A0Theme *theme = [A0Theme sharedInstance];
     self.iconImageView.tintColor = [theme colorForKey:A0ThemeTextFieldIconColor];

--- a/Lock/UI/Private/A0CredentialFieldView.m
+++ b/Lock/UI/Private/A0CredentialFieldView.m
@@ -97,8 +97,8 @@
             break;
         case A0CredentialFieldViewOTPCode:
             self.placeholderText = A0LocalizedString(@"Verification Code");
-            self.textField.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
             self.textField.secureTextEntry = YES;
+            self.textField.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
             self.iconImageView.image = [[theme imageForKey:A0ThemeIconLock] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     }
     self.textField.autocorrectionType = UITextAutocorrectionTypeNo;


### PR DESCRIPTION
- field type for phone number in SMS verification view should be phone number and not email. 
- `secureTextEntry` has to be enabled before changing `keyboardType`