### PR TITLE
Make theme injectable

### DIFF
--- a/Lock/UI/A0LockViewController.h
+++ b/Lock/UI/A0LockViewController.h
@@ -24,7 +24,7 @@
 #import "A0ContainerViewController.h"
 #import "A0LockEventDelegate.h"
 
-@class A0UserProfile, A0Token, A0AuthParameters, A0Lock;
+@class A0UserProfile, A0Token, A0AuthParameters, A0Lock, A0Theme;
 
 typedef void(^A0AuthenticationBlock)(A0UserProfile * __nullable profile, A0Token * __nullable token);
 
@@ -43,6 +43,18 @@ NS_ASSUME_NONNULL_BEGIN
  *  @see A0Lock
  */
 - (instancetype)initWithLock:(A0Lock *)lock;
+
+/**
+ *  Initialize a new instance of the ViewController
+ *
+ *  @param lock an instance of Lock configured for an Auth0 application
+ *  @param theme the theme to use to customize the view controller's look. If nil, the `sharedInstance` on `A0Theme` will be used instead.
+ *  @see A0Lock
+ *  @see A0Theme
+ *  @return an initialized instance.
+ */
+- (instancetype)initWithLock:(A0Lock *)lock theme:(nullable A0Theme *)theme;
+
 
 /**
  *  Initialize a new instance of the ViewController
@@ -95,6 +107,15 @@ NS_ASSUME_NONNULL_BEGIN
  * Hides the Reset Password button. By default is `false`.
  */
 @property (assign, nonatomic) BOOL disableResetPassword;
+
+/**
+ *  The theme to customize the look of the view. By default is nil.
+ *
+ *  You may optionally set this property before presenting the view controller to customize its theme, either directly
+ *  of via `initWithLock: theme:` initializer. If you don't set this property, the `sharedInstance` of `A0Theme` will be 
+ *  used instead.
+ */
+@property (strong, nonatomic) A0Theme *theme;
 
 /**
  *  Hook to use a custom UIViewController for SignUp. By default is nil.

--- a/Lock/UI/A0LockViewController.m
+++ b/Lock/UI/A0LockViewController.m
@@ -76,6 +76,10 @@
 AUTH0_DYNAMIC_LOGGER_METHODS
 
 - (instancetype)initWithLock:(A0Lock *)lock {
+  return [self initWithLock:lock theme:[A0Theme sharedInstance]];
+}
+
+- (instancetype)initWithLock:(A0Lock *)lock theme:(A0Theme *)theme; {
     self = [super init];
     if (self) {
         _usesEmail = YES;
@@ -86,6 +90,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
         _useWebView = YES;
         _eventDelegate = [[A0LockEventDelegate alloc] initWithLockViewController:self];
         _lock = lock;
+        _theme = theme;
     }
     return self;
 }
@@ -115,16 +120,15 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 - (void)setupUI {
     [self setupLayout];
 
-    A0Theme *theme = [A0Theme sharedInstance];
-    UIImage *image = [theme imageForKey:A0ThemeScreenBackgroundImageName];
+    UIImage *image = [self.theme imageForKey:A0ThemeScreenBackgroundImageName];
     if (image) {
         UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
         [self.view insertSubview:imageView atIndex:0];
     }
-    self.view.backgroundColor = [theme colorForKey:A0ThemeScreenBackgroundColor];
-    self.titleView.iconImage = [theme imageForKey:A0ThemeIconImageName];
-    [self.dismissButton setImage:[theme imageForKey:A0ThemeCloseButtonImageName] forState:UIControlStateNormal];
-    self.dismissButton.tintColor = [theme colorForKey:A0ThemeCloseButtonTintColor];
+    self.view.backgroundColor = [self.theme colorForKey:A0ThemeScreenBackgroundColor];
+    self.titleView.iconImage = [self.theme imageForKey:A0ThemeIconImageName];
+    [self.dismissButton setImage:[self.theme imageForKey:A0ThemeCloseButtonImageName] forState:UIControlStateNormal];
+    self.dismissButton.tintColor = [self.theme colorForKey:A0ThemeCloseButtonTintColor];
     self.dismissButton.hidden = !self.closable;
     self.dismissButton.accessibilityElementsHidden = YES;
     [self.dismissButton addTarget:self action:@selector(dismiss:) forControlEvents:UIControlEventTouchUpInside];
@@ -159,11 +163,11 @@ AUTH0_DYNAMIC_LOGGER_METHODS
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return [[A0Theme sharedInstance] statusBarStyle];
+    return [self.theme statusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden {
-    return [[A0Theme sharedInstance] statusBarHidden];
+    return [self.theme statusBarHidden];
 }
 
 #pragma mark - App info fetch


### PR DESCRIPTION
This PR makes `theme` injectable into `A0LockViewController`.

This supports the use-case where an app may need multiple themes or may not desire to always use a singleton instance for the theme.