### PR TITLE
Signup with email and password does not work

### DIFF
--- a/Lock/Core/A0APIClient.m
+++ b/Lock/Core/A0APIClient.m
@@ -199,7 +199,7 @@ AUTH0_DYNAMIC_LOGGER_METHODS
                                   failure:(A0APIClientError)failure {
     A0AuthParameters *defaultParameters = [A0AuthParameters newWithDictionary:@{
                                                                                 kEmailParamName: email,
-                                                                                kUsernameParamName: username ?: email,
+                                                                                kUsernameParamName: username ?: [NSNull null],
                                                                                 kPasswordParamName: password,
                                                                                 kClientIdParamName: self.clientId,
                                                                                 }];


### PR DESCRIPTION
If the iOS client sends "email" as username, it gets an error "Username can only contain alphanumeric characters and '_'. Username cannot have more than 15 characters."
But if the iOS client sends nil for username, the server creates new user with name=email by itself