### PR TITLE
Fixing build for macOS

### DIFF
--- a/CocoaPods/Lock.h
+++ b/CocoaPods/Lock.h
@@ -41,31 +41,31 @@
 #import "A0LockLogger.h"
 #import "A0LockNotification.h"
 
-#if __has_include("UI.h")
+#if TARGET_OS_IOS && __has_include("UI.h")
 #import "UI.h"
 #endif
 
-#if __has_include("A0Theme.h")
+#if TARGET_OS_IOS && __has_include("A0Theme.h")
 #import "A0Theme.h"
 #import "A0ServiceTheme.h"
 #endif
 
-#if __has_include("A0TouchIDLockViewController.h")
+#if TARGET_OS_IOS && __has_include("A0TouchIDLockViewController.h")
 #import "A0TouchIDLockViewController.h"
 #import "A0Lock+A0TouchIDLockViewController.h"
 #endif
 
-#if __has_include("A0SMSLockViewController.h")
+#if TARGET_OS_IOS && __has_include("A0SMSLockViewController.h")
 #import "A0Lock+A0SMSLockViewController.h"
 #import "A0SMSLockViewController.h"
 #endif
 
-#if __has_include("A0EmailLockViewController.h")
+#if TARGET_OS_IOS && __has_include("A0EmailLockViewController.h")
 #import "A0Lock+A0EmailLockViewController.h"
 #import "A0EmailLockViewController.h"
 #endif
 
-#if __has_include("A0WebViewAuthenticator.h")
+#if TARGET_OS_IOS && __has_include("A0WebViewAuthenticator.h")
 #import "A0WebViewAuthenticator.h"
 #endif
 

--- a/Lock/Provider/A0IdentityProviderAuthenticator.m
+++ b/Lock/Provider/A0IdentityProviderAuthenticator.m
@@ -30,7 +30,7 @@
 #import "Constants.h"
 #import "A0FailureAuthenticator.h"
 
-#if __has_include(<Lock/A0WebViewAuthenticator.h>)
+#if TARGET_OS_IOS && __has_include(<Lock/A0WebViewAuthenticator.h>)
 #define HAS_WEBVIEW_SUPPORT 1
 #import <Lock/A0WebViewAuthenticator.h>
 #endif


### PR DESCRIPTION
### Description

The project doesn't build for macOS. The compiler error is:

    File not found: 'UIKit/UIKit.h'
    From A0WebViewAuthentication.h : Line 35
    In file included from "Lock/Provider/A0IdentityProviderAuthenticator.m"

The code in question is :

```objective-c
#if __has_include(<Lock/A0WebViewAuthenticator.h>)
#define HAS_WEBVIEW_SUPPORT 1
#import <Lock/A0WebViewAuthenticator.h>
#endif
```

It seems that the "has_include" directive fails **when the project includes both an iOS and a macOS target**.

### Instructions to Reproduce:

- Download [this zip file](https://github.com/auth0/Lock.iOS-OSX/files/414397/Quack.zip) (which contains sample Xcode project)
- Do a "pod install" using the Podfile as is (with normal "Pod 'Lock'")
- Open Quack.xcworkspace
- Attempt to compile both the "Quack_macOS" & "Quack_iOS" targets
- Witness the compiler error
- Modify the Podfile and switch **BOTH** "Pod 'Lock'" statements to the other version
- Do another "pod install"
- Now compile both the "Quack_macOS" & "Quack_iOS" targets