### PR TITLE
Allow developer to get controller to show lock.

### DIFF
--- a/Lock/Router.swift
+++ b/Lock/Router.swift
@@ -50,11 +50,17 @@ class Router: Navigable {
             }
         }
         self.onAuthentication = { [weak controller] credentials in
-            Queue.main.async {
-                controller?.presentingViewController?.dismiss(animated: true, completion: { _ in
-                    lock.callback(.success(credentials))
-                })
+            let closure: () -> ()
+            if let presentingController = controller?.presentingViewController {
+                closure = {
+                    presentingController.dismiss(animated: true, completion: { _ in
+                        lock.callback(.success(credentials))
+                    })
+                }
+            } else {
+                closure = { lock.callback(.success(credentials)) }
             }
+            Queue.main.async(closure)
         }
 
         self.onBack = {

--- a/LockTests/Router/RouterSpec.swift
+++ b/LockTests/Router/RouterSpec.swift
@@ -145,6 +145,20 @@ class RouterSpec: QuickSpec {
                 }
             }
 
+            it("should call callback with auth result when lock was displayed without present") {
+                controller.presenting = nil
+                let credentials = Credentials(accessToken: "ACCESS_TOKEN", tokenType: "bearer")
+                waitUntil(timeout: 2) { done in
+                    lock.callback = { result in
+                        if case .success(let actual) = result {
+                            expect(actual) == credentials
+                            done()
+                        }
+                    }
+                    router.onAuthentication(credentials)
+                }
+            }
+
             describe("back") {
 
                 beforeEach {


### PR DESCRIPTION
Always calls callback on success/critical error even if lock was not presented