### PR TITLE
Using Safari for web auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,48 @@ And you'll see our native login screen
 
 [![Lock.png](http://blog.auth0.com.s3.amazonaws.com/Lock-Widget-Screenshot.png)](https://auth0.com)
 
-> By default all social authentication will be done using Safari, if you want native integration please check this [docs page](https://auth0.com/docs/libraries/lock-ios/native-social-authentication).
+> By default all social authentication will be done using web based authentication, if you want native integration please check this [docs page](https://auth0.com/docs/libraries/lock-ios/native-social-authentication).
 
-Also you can check our [Swift](https://github.com/auth0/Lock.iOS-OSX/tree/master/Examples/basic-sample-swift) and [Objective-C](https://github.com/auth0/Lock.iOS-OSX/tree/master/Examples/basic-sample) example apps. For more information on how to use **Lock** with Swift please check [this guide](https://github.com/auth0/Lock.iOS-OSX/wiki/Lock-&-Swift)
+Also you can check our quickstart guides for:
+- [Swift](https://auth0.com/docs/quickstart/native/ios-swift)
+- [Objective-C](https://auth0.com/docs/quickstart/native/ios-objc)
+
+#### Important: Google Connections
+
+Google recently announced they will no longer support web-views, it is *highly recommended* you update your code to use Safari for web based authentication.
+
+##### Podfile
+
+Update your Podfile to include:
+
+```ruby
+pod 'Lock/Safari'
+```
+
+You should add the following code before you present Lock to the user. If you have multiple connections you wish to
+use with Safari you will need to specify each one manually as above.
+
+To use Safari for the default Google social connection, add the following:
+
+##### Objective-C
+
+```objc
+#import <Lock/A0SafariAuthenticator.h>
+```
+
+```objc
+A0Lock *lock = [A0Lock sharedLock];
+A0SafariAuthenticator *safari = [[A0SafariAuthenticator alloc] initWithLock:lock connectionName:@"google-oauth2"];
+[lock registerAuthenticators:@[safari]];   
+```
+
+##### Swift
+
+```swift
+let lock = A0Lock.shared()
+let safari = A0SafariAuthenticator(lock: lock, connectionName: "google-oauth2")
+lock.registerAuthenticators([safari])    
+```
 
 ### TouchID
 


### PR DESCRIPTION
Replaced retired information with Quickstart guides