### PR TITLE
Fixing long delay on macOS

### DIFF
--- a/Lock/Core/OSX/A0DeviceNameProvider.m
+++ b/Lock/Core/OSX/A0DeviceNameProvider.m
@@ -24,8 +24,12 @@
 
 @implementation A0DeviceNameProvider
 
-+ (NSString *)deviceName {
-    return [[NSHost currentHost] name];
++ (NSString *)deviceName
+{
+	// This causes long delays (~ 20 seconds) on some machines.
+//	return [[NSHost currentHost] name];
+	
+	return [[NSHost currentHost] localizedName];
 }
 
 @end


### PR DESCRIPTION
I've noticed a problem with ```[[NSHost currentHost] name]```. On particular networks this call will block for up to 20 seconds!

From some brief research on the topic, I've found:
- An [older discussion](http://www.cocoabuilder.com/archive/cocoa/124913-nshost-currenthost-slow.html) seems to link the problem with particular routers, or IP ranges.
- In [the past](https://lists.apple.com/archives/cocoa-dev/2009/Sep/msg00680.html) people have recommended using SCDynamicStoreCopyLocalHostName instead.

But I was able to reproduce it recently, and it seems that ```[[NSHost currentHost] localizedName]``` does the trick (no more delays).